### PR TITLE
feat(core): add seedable dice roller with advantage/disadvantage

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -1,1 +1,70 @@
-console.log('Hello from GrimEngine CLI');
+import { roll } from '@grimengine/core';
+
+function showUsage(): void {
+  console.log('Usage: pnpm dev -- roll "<expression>" [adv|dis] [--seed <value>]');
+}
+
+const [, , ...argv] = process.argv;
+const [command, ...rawArgs] = argv[0] === '--' ? argv.slice(1) : argv;
+
+if (!command || command === 'help' || command === '--help') {
+  showUsage();
+  process.exit(0);
+}
+
+if (command !== 'roll') {
+  console.error(`Unknown command: ${command}`);
+  showUsage();
+  process.exit(1);
+}
+
+if (rawArgs.length === 0) {
+  console.error('Missing dice expression.');
+  showUsage();
+  process.exit(1);
+}
+
+const expression = rawArgs[0];
+let advantage = false;
+let disadvantage = false;
+let seed: string | undefined;
+
+for (let i = 1; i < rawArgs.length; i += 1) {
+  const arg = rawArgs[i];
+  const lower = arg.toLowerCase();
+  if (lower === 'adv' || lower === 'advantage') {
+    advantage = true;
+    continue;
+  }
+  if (lower === 'dis' || lower === 'disadvantage' || lower === 'disadv') {
+    disadvantage = true;
+    continue;
+  }
+  if (arg.startsWith('--seed=')) {
+    seed = arg.slice('--seed='.length);
+    continue;
+  }
+  if (lower === '--seed') {
+    if (i + 1 >= rawArgs.length) {
+      console.error('Expected value after --seed.');
+      process.exit(1);
+    }
+    seed = rawArgs[i + 1];
+    i += 1;
+    continue;
+  }
+
+  console.warn(`Ignoring unknown argument: ${arg}`);
+}
+
+if (advantage && disadvantage) {
+  console.error('Cannot roll with both advantage and disadvantage.');
+  process.exit(1);
+}
+
+const advLabel = advantage ? ' with advantage' : disadvantage ? ' with disadvantage' : '';
+console.log(`Rolling ${expression}${advLabel}...`);
+
+const result = roll(expression, { advantage, disadvantage, seed });
+
+console.log(`Rolls: [${result.rolls.join(', ')}] → total ${result.total}`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@grimengine/core",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./dice": "./src/dice.ts"
+  },
+  "scripts": {
+    "test": "vitest"
+  }
+}

--- a/packages/core/src/dice.ts
+++ b/packages/core/src/dice.ts
@@ -1,0 +1,141 @@
+import seedrandom from './vendor-seedrandom.js';
+
+export interface RollOptions {
+  seed?: string;
+  advantage?: boolean;
+  disadvantage?: boolean;
+}
+
+export interface RollResult {
+  total: number;
+  rolls: number[];
+  expression: string;
+}
+
+type Term =
+  | { type: 'dice'; sign: 1 | -1; count: number; sides: number }
+  | { type: 'number'; sign: 1 | -1; value: number };
+
+const TERM_PATTERN = /[+-]?[^+-]+/g;
+
+function parseExpression(expr: string): { terms: Term[]; normalized: string } {
+  const compact = expr.replace(/\s+/g, '');
+  if (!compact) {
+    throw new Error('Empty dice expression');
+  }
+
+  const tokens = compact.match(TERM_PATTERN);
+  if (!tokens) {
+    throw new Error(`Invalid dice expression: ${expr}`);
+  }
+
+  const terms: Term[] = [];
+
+  tokens.forEach((rawToken) => {
+    let token = rawToken;
+    let sign: 1 | -1 = 1;
+    if (token.startsWith('+')) {
+      token = token.slice(1);
+    } else if (token.startsWith('-')) {
+      sign = -1;
+      token = token.slice(1);
+    }
+
+    if (!token) {
+      throw new Error(`Invalid token in expression: ${rawToken}`);
+    }
+
+    const diceMatch = token.match(/^(\d*)d(\d+)$/i);
+    if (diceMatch) {
+      const [, countStr, sidesStr] = diceMatch;
+      const count = countStr ? Number.parseInt(countStr, 10) : 1;
+      const sides = Number.parseInt(sidesStr, 10);
+
+      if (!Number.isFinite(count) || count < 1) {
+        throw new Error(`Invalid dice count in token: ${rawToken}`);
+      }
+
+      if (!Number.isFinite(sides) || sides < 2) {
+        throw new Error(`Invalid dice sides in token: ${rawToken}`);
+      }
+
+      terms.push({ type: 'dice', sign, count, sides });
+      return;
+    }
+
+    const value = Number.parseInt(token, 10);
+    if (!Number.isFinite(value)) {
+      throw new Error(`Invalid modifier in token: ${rawToken}`);
+    }
+
+    terms.push({ type: 'number', sign, value });
+  });
+
+  const normalized = terms
+    .map((term, index) => {
+      const body = term.type === 'dice' ? `${term.count}d${term.sides}` : `${term.value}`;
+      if (index === 0) {
+        return term.sign === -1 ? `-${body}` : body;
+      }
+      const prefix = term.sign === -1 ? '-' : '+';
+      return `${prefix}${body}`;
+    })
+    .join('');
+
+  return { terms, normalized };
+}
+
+function rollDie(sides: number, random: () => number): number {
+  return Math.floor(random() * sides) + 1;
+}
+
+export function roll(expr: string, opts: RollOptions = {}): RollResult {
+  if (opts.advantage && opts.disadvantage) {
+    throw new Error('Cannot roll with both advantage and disadvantage');
+  }
+
+  const { terms, normalized } = parseExpression(expr);
+  const rng = seedrandom(opts.seed);
+
+  const rolls: number[] = [];
+  let total = 0;
+
+  const advantageRequested = Boolean(opts.advantage || opts.disadvantage);
+  let advantageApplied = false;
+
+  const targetIndex = advantageRequested
+    ? terms.findIndex((term) => term.type === 'dice' && term.count === 1 && term.sides === 20)
+    : -1;
+
+  terms.forEach((term, index) => {
+    if (term.type === 'dice') {
+      const shouldApplyAdvantage =
+        advantageRequested && !advantageApplied && (index === targetIndex || targetIndex === -1);
+
+      if (shouldApplyAdvantage && term.count === 1) {
+        const first = rollDie(term.sides, rng);
+        const second = rollDie(term.sides, rng);
+        rolls.push(first, second);
+        const chosen = opts.advantage ? Math.max(first, second) : Math.min(first, second);
+        total += term.sign * chosen;
+        advantageApplied = true;
+      } else {
+        for (let i = 0; i < term.count; i += 1) {
+          const value = rollDie(term.sides, rng);
+          rolls.push(value);
+          total += term.sign * value;
+        }
+      }
+    } else {
+      total += term.sign * term.value;
+    }
+  });
+
+  const expression = `${normalized}${opts.advantage ? ' adv' : opts.disadvantage ? ' dis' : ''}`;
+
+  return {
+    total,
+    rolls,
+    expression,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,2 @@
+export { roll } from './dice.js';
+export type { RollOptions, RollResult } from './dice.js';

--- a/packages/core/src/vendor-seedrandom.ts
+++ b/packages/core/src/vendor-seedrandom.ts
@@ -1,0 +1,34 @@
+export type SeedGenerator = () => number;
+
+function xmur3(str: string): () => number {
+  let h = 1779033703 ^ str.length;
+  for (let i = 0; i < str.length; i += 1) {
+    h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  return function next() {
+    h = Math.imul(h ^ (h >>> 16), 2246822507);
+    h = Math.imul(h ^ (h >>> 13), 3266489909);
+    h ^= h >>> 16;
+    return h >>> 0;
+  };
+}
+
+function mulberry32(seed: number): SeedGenerator {
+  let t = seed >>> 0;
+  return function generate() {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    const result = ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+    return result;
+  };
+}
+
+export default function seedrandom(seed?: string): SeedGenerator {
+  if (!seed) {
+    return Math.random;
+  }
+  const seedFactory = xmur3(seed);
+  return mulberry32(seedFactory());
+}

--- a/packages/core/tests/dice.test.ts
+++ b/packages/core/tests/dice.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { roll } from '../src/dice.js';
+
+describe('roll', () => {
+  it('rolls a single die', () => {
+    const result = roll('1d6', { seed: 'simple' });
+    expect(result.rolls).toEqual([3]);
+    expect(result.total).toBe(3);
+    expect(result.expression).toBe('1d6');
+  });
+
+  it('applies modifiers', () => {
+    const result = roll('2d6+3', { seed: 'mods' });
+    expect(result.rolls).toEqual([1, 2]);
+    expect(result.total).toBe(6);
+    expect(result.expression).toBe('2d6+3');
+  });
+
+  it('supports advantage and disadvantage', () => {
+    const advantage = roll('1d20+5', { seed: 'hero', advantage: true });
+    expect(advantage.rolls).toEqual([7, 12]);
+    expect(advantage.total).toBe(17);
+    expect(advantage.expression).toBe('1d20+5 adv');
+
+    const disadvantage = roll('1d20+5', { seed: 'hero', disadvantage: true });
+    expect(disadvantage.rolls).toEqual([7, 12]);
+    expect(disadvantage.total).toBe(12);
+    expect(disadvantage.expression).toBe('1d20+5 dis');
+  });
+
+  it('produces deterministic results with a seed', () => {
+    const first = roll('1d20', { seed: 'repeatable' });
+    const second = roll('1d20', { seed: 'repeatable' });
+    expect(second).toEqual(first);
+  });
+});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src", "tests"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,11 @@
     // File Layout
     "rootDir": ".",
     "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "@grimengine/core": ["packages/core/src/index.ts"],
+      "@grimengine/core/*": ["packages/core/src/*"]
+    },
 
     // Environment Settings
     // See also https://aka.ms/tsconfig/module

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
-  "": "https://turborepo.org/schema.json",
-  "pipeline": {
+  "$schema": "https://turborepo.org/schema.json",
+  "tasks": {
     "build": { "dependsOn": ["^build"], "outputs": ["dist/**"] },
     "lint": {},
     "test": { "dependsOn": ["^build"] }


### PR DESCRIPTION
## Summary
- add a core dice roller with deterministic seeding, modifiers, and advantage/disadvantage handling
- expose the roller through a new `@grimengine/core` package with tests and a vendored PRNG helper
- wire the CLI with a `roll` command and update repo config to reference the new workspace

## Testing
- pnpm test
- pnpm dev -- roll "1d20+5" adv --seed hero

------
https://chatgpt.com/codex/tasks/task_e_68dd91d91f2c8327947a1e2723d50c05