### PR TITLE
feat(core): add ability score utilities and CLI commands

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -1,70 +1,238 @@
-import { roll } from '@grimengine/core';
+import {
+  roll,
+  rollAbilityScores,
+  standardArray,
+  validatePointBuy,
+} from '@grimengine/core';
 
 function showUsage(): void {
-  console.log('Usage: pnpm dev -- roll "<expression>" [adv|dis] [--seed <value>]');
+  console.log('Usage:');
+  console.log('  pnpm dev -- roll "<expression>" [adv|dis] [--seed <value>]');
+  console.log('  pnpm dev -- abilities roll [--seed <value>] [--count <n>] [--drop <n>] [--sort asc|desc|none]');
+  console.log('  pnpm dev -- abilities standard');
+  console.log('  pnpm dev -- abilities pointbuy "<comma-separated scores>"');
 }
 
 const [, , ...argv] = process.argv;
-const [command, ...rawArgs] = argv[0] === '--' ? argv.slice(1) : argv;
+const args = argv[0] === '--' ? argv.slice(1) : argv;
 
-if (!command || command === 'help' || command === '--help') {
+if (args.length === 0 || args[0] === 'help' || args[0] === '--help') {
   showUsage();
   process.exit(0);
 }
 
-if (command !== 'roll') {
-  console.error(`Unknown command: ${command}`);
-  showUsage();
-  process.exit(1);
+const [command, ...rest] = args;
+
+if (command === 'roll') {
+  if (rest.length === 0) {
+    console.error('Missing dice expression.');
+    showUsage();
+    process.exit(1);
+  }
+
+  const [expression, ...rawArgs] = rest;
+  let advantage = false;
+  let disadvantage = false;
+  let seed: string | undefined;
+
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+    const lower = arg.toLowerCase();
+    if (lower === 'adv' || lower === 'advantage') {
+      advantage = true;
+      continue;
+    }
+    if (lower === 'dis' || lower === 'disadvantage' || lower === 'disadv') {
+      disadvantage = true;
+      continue;
+    }
+    if (arg.startsWith('--seed=')) {
+      seed = arg.slice('--seed='.length);
+      continue;
+    }
+    if (lower === '--seed') {
+      if (i + 1 >= rawArgs.length) {
+        console.error('Expected value after --seed.');
+        process.exit(1);
+      }
+      seed = rawArgs[i + 1];
+      i += 1;
+      continue;
+    }
+
+    console.warn(`Ignoring unknown argument: ${arg}`);
+  }
+
+  if (advantage && disadvantage) {
+    console.error('Cannot roll with both advantage and disadvantage.');
+    process.exit(1);
+  }
+
+  const advLabel = advantage ? ' with advantage' : disadvantage ? ' with disadvantage' : '';
+  console.log(`Rolling ${expression}${advLabel}...`);
+
+  const result = roll(expression, { advantage, disadvantage, seed });
+
+  console.log(`Rolls: [${result.rolls.join(', ')}] → total ${result.total}`);
+  process.exit(0);
 }
 
-if (rawArgs.length === 0) {
-  console.error('Missing dice expression.');
-  showUsage();
-  process.exit(1);
-}
+if (command === 'abilities') {
+  if (rest.length === 0) {
+    console.error('Missing abilities subcommand.');
+    showUsage();
+    process.exit(1);
+  }
 
-const expression = rawArgs[0];
-let advantage = false;
-let disadvantage = false;
-let seed: string | undefined;
+  const [subcommand, ...rawArgs] = rest;
 
-for (let i = 1; i < rawArgs.length; i += 1) {
-  const arg = rawArgs[i];
-  const lower = arg.toLowerCase();
-  if (lower === 'adv' || lower === 'advantage') {
-    advantage = true;
-    continue;
+  if (subcommand === 'roll') {
+    let seed: string | undefined;
+    let count: number | undefined;
+    let drop: number | undefined;
+    let sort: 'none' | 'asc' | 'desc' | undefined;
+
+    for (let i = 0; i < rawArgs.length; i += 1) {
+      const arg = rawArgs[i];
+      if (arg.startsWith('--seed=')) {
+        seed = arg.slice('--seed='.length);
+        continue;
+      }
+      if (arg === '--seed') {
+        if (i + 1 >= rawArgs.length) {
+          console.error('Expected value after --seed.');
+          process.exit(1);
+        }
+        seed = rawArgs[i + 1];
+        i += 1;
+        continue;
+      }
+      if (arg.startsWith('--count=')) {
+        const value = Number.parseInt(arg.slice('--count='.length), 10);
+        if (Number.isNaN(value) || value <= 0) {
+          console.error('Count must be a positive integer.');
+          process.exit(1);
+        }
+        count = value;
+        continue;
+      }
+      if (arg === '--count') {
+        if (i + 1 >= rawArgs.length) {
+          console.error('Expected value after --count.');
+          process.exit(1);
+        }
+        const value = Number.parseInt(rawArgs[i + 1], 10);
+        if (Number.isNaN(value) || value <= 0) {
+          console.error('Count must be a positive integer.');
+          process.exit(1);
+        }
+        count = value;
+        i += 1;
+        continue;
+      }
+      if (arg.startsWith('--drop=')) {
+        const value = Number.parseInt(arg.slice('--drop='.length), 10);
+        if (Number.isNaN(value) || value < 0) {
+          console.error('Drop must be zero or a positive integer.');
+          process.exit(1);
+        }
+        drop = value;
+        continue;
+      }
+      if (arg === '--drop') {
+        if (i + 1 >= rawArgs.length) {
+          console.error('Expected value after --drop.');
+          process.exit(1);
+        }
+        const value = Number.parseInt(rawArgs[i + 1], 10);
+        if (Number.isNaN(value) || value < 0) {
+          console.error('Drop must be zero or a positive integer.');
+          process.exit(1);
+        }
+        drop = value;
+        i += 1;
+        continue;
+      }
+      if (arg.startsWith('--sort=')) {
+        const value = arg.slice('--sort='.length);
+        if (value === 'asc' || value === 'desc' || value === 'none') {
+          sort = value;
+        } else {
+          console.error('Sort must be one of: asc, desc, none.');
+          process.exit(1);
+        }
+        continue;
+      }
+      if (arg === '--sort') {
+        if (i + 1 >= rawArgs.length) {
+          console.error('Expected value after --sort.');
+          process.exit(1);
+        }
+        const value = rawArgs[i + 1];
+        if (value === 'asc' || value === 'desc' || value === 'none') {
+          sort = value;
+        } else {
+          console.error('Sort must be one of: asc, desc, none.');
+          process.exit(1);
+        }
+        i += 1;
+        continue;
+      }
+
+      console.warn(`Ignoring unknown argument: ${arg}`);
+    }
+
+    const { sets, details } = rollAbilityScores({ seed, count, drop, sort });
+    const sortLabel = sort ? sort : 'none';
+
+    console.log(`Ability Scores (4d6 drop lowest, seed=${seed ? `"${seed}"` : 'none'}, sort=${sortLabel})`);
+    console.log(`Sets: [${sets.join(', ')}]`);
+    const detailStrings = details
+      .map((rolls, index) => {
+        const total = sets[index];
+        return `[${rolls.join(',')}] -> ${total}`;
+      })
+      .join(', ');
+    console.log(`Details per stat: [${detailStrings}]`);
+    process.exit(0);
   }
-  if (lower === 'dis' || lower === 'disadvantage' || lower === 'disadv') {
-    disadvantage = true;
-    continue;
+
+  if (subcommand === 'standard') {
+    console.log(`Standard Array: [${standardArray().join(', ')}]`);
+    process.exit(0);
   }
-  if (arg.startsWith('--seed=')) {
-    seed = arg.slice('--seed='.length);
-    continue;
-  }
-  if (lower === '--seed') {
-    if (i + 1 >= rawArgs.length) {
-      console.error('Expected value after --seed.');
+
+  if (subcommand === 'pointbuy') {
+    if (rawArgs.length === 0) {
+      console.error('Missing ability scores for point buy.');
+      showUsage();
       process.exit(1);
     }
-    seed = rawArgs[i + 1];
-    i += 1;
-    continue;
+
+    const scores = rawArgs[0]
+      .split(',')
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+      .map((value) => Number.parseInt(value, 10));
+
+    const result = validatePointBuy(scores);
+
+    if (result.ok) {
+      console.log(`Point Buy: OK (cost ${result.cost} / budget ${result.budget})`);
+    } else {
+      console.log('Point Buy: INVALID');
+      result.errors.forEach((message) => {
+        console.log(`- ${message}`);
+      });
+    }
+    process.exit(result.ok ? 0 : 1);
   }
 
-  console.warn(`Ignoring unknown argument: ${arg}`);
-}
-
-if (advantage && disadvantage) {
-  console.error('Cannot roll with both advantage and disadvantage.');
+  console.error(`Unknown abilities subcommand: ${subcommand}`);
+  showUsage();
   process.exit(1);
 }
 
-const advLabel = advantage ? ' with advantage' : disadvantage ? ' with disadvantage' : '';
-console.log(`Rolling ${expression}${advLabel}...`);
-
-const result = roll(expression, { advantage, disadvantage, seed });
-
-console.log(`Rolls: [${result.rolls.join(', ')}] → total ${result.total}`);
+console.error(`Unknown command: ${command}`);
+showUsage();
+process.exit(1);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,8 @@
   "main": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./dice": "./src/dice.ts"
+    "./dice": "./src/dice.ts",
+    "./abilityScores": "./src/abilityScores.ts"
   },
   "scripts": {
     "test": "vitest"

--- a/packages/core/src/abilityScores.ts
+++ b/packages/core/src/abilityScores.ts
@@ -1,0 +1,169 @@
+import seedrandom from './vendor-seedrandom.js';
+
+export type AbilityName = 'STR' | 'DEX' | 'CON' | 'INT' | 'WIS' | 'CHA';
+export type AbilityScores = Record<AbilityName, number>;
+
+export interface AbilityRollOptions {
+  seed?: string;
+  count?: number;
+  drop?: number;
+  sort?: 'none' | 'asc' | 'desc';
+}
+
+export interface PointBuyOptions {
+  budget?: number;
+  min?: number;
+  max?: number;
+}
+
+type AbilityScoreRollResult = {
+  total: number;
+  rolls: number[];
+};
+
+const DEFAULT_COUNT = 6;
+const DEFAULT_DROP = 1;
+const DEFAULT_SORT: NonNullable<AbilityRollOptions['sort']> = 'none';
+const DEFAULT_POINT_BUY_BUDGET = 27;
+const DEFAULT_POINT_BUY_MIN = 8;
+const DEFAULT_POINT_BUY_MAX = 15;
+
+const POINT_BUY_COST: Record<number, number> = {
+  8: 0,
+  9: 1,
+  10: 2,
+  11: 3,
+  12: 4,
+  13: 5,
+  14: 7,
+  15: 9,
+};
+
+function clampDrop(value: number, sides: number): number {
+  if (Number.isNaN(value) || value < 0) {
+    return 0;
+  }
+
+  if (value >= sides) {
+    return sides - 1;
+  }
+
+  return Math.floor(value);
+}
+
+export function roll4d6DropLowest(
+  rng: () => number,
+  drop: number = DEFAULT_DROP,
+): AbilityScoreRollResult {
+  const rolls: number[] = [];
+  for (let i = 0; i < 4; i += 1) {
+    rolls.push(Math.floor(rng() * 6) + 1);
+  }
+
+  const dropCount = clampDrop(drop, rolls.length);
+  const sorted = [...rolls].sort((a, b) => a - b);
+  const kept = sorted.slice(dropCount);
+  const total = kept.reduce((sum, value) => sum + value, 0);
+
+  return { rolls, total };
+}
+
+export function rollAbilityScores(opts: AbilityRollOptions = {}): { sets: number[]; details: number[][] } {
+  const { seed, count = DEFAULT_COUNT, drop = DEFAULT_DROP, sort = DEFAULT_SORT } = opts;
+  const rng = seedrandom(seed);
+
+  const finalCount = Number.isFinite(count) && count > 0 ? Math.floor(count) : DEFAULT_COUNT;
+  const finalSort: 'none' | 'asc' | 'desc' = sort === 'asc' || sort === 'desc' ? sort : DEFAULT_SORT;
+
+  const results: AbilityScoreRollResult[] = [];
+  for (let i = 0; i < finalCount; i += 1) {
+    results.push(roll4d6DropLowest(rng, drop));
+  }
+
+  const sortedResults = (() => {
+    if (finalSort === 'asc') {
+      return [...results].sort((a, b) => a.total - b.total);
+    }
+    if (finalSort === 'desc') {
+      return [...results].sort((a, b) => b.total - a.total);
+    }
+    return results;
+  })();
+
+  return {
+    sets: sortedResults.map((result) => result.total),
+    details: sortedResults.map((result) => result.rolls),
+  };
+}
+
+export function standardArray(): number[] {
+  return [15, 14, 13, 12, 10, 8];
+}
+
+export function calculatePointBuyCost(arr: number[]): number {
+  return arr.reduce((sum, value) => {
+    const cost = POINT_BUY_COST[value];
+    if (typeof cost !== 'number') {
+      throw new Error(`Invalid ability score ${value} for point buy`);
+    }
+    return sum + cost;
+  }, 0);
+}
+
+export function validatePointBuy(
+  arr: number[],
+  opts: PointBuyOptions = {},
+): { ok: boolean; cost: number; budget: number; errors: string[] } {
+  const budget = opts.budget ?? DEFAULT_POINT_BUY_BUDGET;
+  const min = opts.min ?? DEFAULT_POINT_BUY_MIN;
+  const max = opts.max ?? DEFAULT_POINT_BUY_MAX;
+
+  const errors: string[] = [];
+  const values = arr ?? [];
+
+  if (values.length !== DEFAULT_COUNT) {
+    errors.push(`Expected 6 ability scores, received ${values.length}`);
+  }
+
+  let cost = 0;
+  values.forEach((value, index) => {
+    if (!Number.isFinite(value)) {
+      errors.push(`Value at index ${index} is not a number`);
+      return;
+    }
+
+    if (!Number.isInteger(value)) {
+      errors.push(`Value ${value} must be an integer`);
+      return;
+    }
+
+    if (value < min) {
+      errors.push(`Value ${value} is below minimum ${min}`);
+      return;
+    }
+
+    if (value > max) {
+      errors.push(`Value ${value} exceeds maximum ${max}`);
+      return;
+    }
+
+    const pointCost = POINT_BUY_COST[value];
+    if (typeof pointCost !== 'number') {
+      errors.push(`No point-buy cost configured for value ${value}`);
+      return;
+    }
+
+    cost += pointCost;
+  });
+
+  if (cost > budget) {
+    errors.push(`Total cost ${cost} exceeds budget ${budget}`);
+  }
+
+  return {
+    ok: errors.length === 0,
+    cost,
+    budget,
+    errors,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,15 @@
 export { roll } from './dice.js';
 export type { RollOptions, RollResult } from './dice.js';
+export {
+  roll4d6DropLowest,
+  rollAbilityScores,
+  standardArray,
+  calculatePointBuyCost,
+  validatePointBuy,
+} from './abilityScores.js';
+export type {
+  AbilityName,
+  AbilityScores,
+  AbilityRollOptions,
+  PointBuyOptions,
+} from './abilityScores.js';

--- a/packages/core/tests/abilityScores.test.ts
+++ b/packages/core/tests/abilityScores.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  roll4d6DropLowest,
+  rollAbilityScores,
+  standardArray,
+  calculatePointBuyCost,
+  validatePointBuy,
+} from '../src/abilityScores.js';
+
+describe('ability scores', () => {
+  it('roll4d6DropLowest returns four rolls and sum of top dice', () => {
+    const mockRolls = [0.99, 0.2, 0.75, 0.35];
+    let index = 0;
+    const rng = () => mockRolls[index++];
+    const result = roll4d6DropLowest(rng, 1);
+    expect(result.rolls).toEqual([6, 2, 5, 3]);
+    expect(result.total).toBe(6 + 5 + 3);
+  });
+
+  it('rollAbilityScores with seed is deterministic', () => {
+    const first = rollAbilityScores({ seed: 'x' });
+    const second = rollAbilityScores({ seed: 'x' });
+    expect(first.sets).toEqual(second.sets);
+    expect(first.sets).toHaveLength(6);
+  });
+
+  it('rollAbilityScores respects sorting options', () => {
+    const base = rollAbilityScores({ seed: 'sort-test' });
+    const asc = rollAbilityScores({ seed: 'sort-test', sort: 'asc' });
+    const desc = rollAbilityScores({ seed: 'sort-test', sort: 'desc' });
+
+    const ascending = [...base.sets].sort((a, b) => a - b);
+    const descending = [...ascending].reverse();
+
+    expect(asc.sets).toEqual(ascending);
+    expect(desc.sets).toEqual(descending);
+  });
+
+  it('standardArray returns the expected numbers', () => {
+    expect(standardArray()).toEqual([15, 14, 13, 12, 10, 8]);
+  });
+
+  it('calculatePointBuyCost computes PHB total', () => {
+    expect(calculatePointBuyCost([15, 14, 13, 12, 10, 8])).toBe(27);
+  });
+
+  describe('validatePointBuy', () => {
+    it('accepts standard array', () => {
+      const result = validatePointBuy([15, 14, 13, 12, 10, 8]);
+      expect(result.ok).toBe(true);
+      expect(result.cost).toBe(27);
+    });
+
+    it('rejects values out of bounds', () => {
+      const result = validatePointBuy([16, 7, 10, 10, 10, 10]);
+      expect(result.ok).toBe(false);
+      expect(result.errors).toEqual([
+        'Value 16 exceeds maximum 15',
+        'Value 7 is below minimum 8',
+      ]);
+    });
+
+    it('reports when total cost exceeds the budget', () => {
+      const result = validatePointBuy([15, 15, 15, 15, 15, 15], { budget: 40 });
+      expect(result.ok).toBe(false);
+      expect(result.errors).toEqual(['Total cost 54 exceeds budget 40']);
+    });
+
+    it('reports incorrect count', () => {
+      const result = validatePointBuy([15, 14, 13, 12, 10]);
+      expect(result.ok).toBe(false);
+      expect(result.errors).toContain('Expected 6 ability scores, received 5');
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.6.1)(tsx@4.20.6)
 
+  packages/core: {}
+
 packages:
 
   '@ampproject/remapping@2.3.0':


### PR DESCRIPTION
## Summary
- add core ability score utilities for rolling, standard array, and point-buy validation
- expose the new helpers through the core package and wire them into the CLI abilities subcommands
- cover the ability score logic with Vitest cases

## Testing
- pnpm test
- pnpm dev -- abilities standard
- pnpm dev -- abilities roll --seed grim --count 6 --drop 1 --sort desc
- pnpm dev -- abilities pointbuy "15,14,13,12,10,8"
- pnpm dev -- abilities pointbuy "7,14,13,12,10,8"

------
https://chatgpt.com/codex/tasks/task_e_68de72a49f1c83279acb5ac4b4c96509