### PR TITLE
feat(core): add ability checks and saving throws

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -1,16 +1,209 @@
 import {
+  abilityCheck,
   roll,
   rollAbilityScores,
+  savingThrow,
   standardArray,
   validatePointBuy,
+  type AbilityName,
 } from '@grimengine/core';
 
 function showUsage(): void {
   console.log('Usage:');
   console.log('  pnpm dev -- roll "<expression>" [adv|dis] [--seed <value>]');
+  console.log('  pnpm dev -- check <ability> [modifier] [--dc <n>] [--proficient] [--pb <n>] [--adv|--dis] [--seed <value>]');
+  console.log('  pnpm dev -- save <ability> [modifier] [--dc <n>] [--proficient] [--pb <n>] [--adv|--dis] [--seed <value>]');
   console.log('  pnpm dev -- abilities roll [--seed <value>] [--count <n>] [--drop <n>] [--sort asc|desc|none]');
   console.log('  pnpm dev -- abilities standard');
   console.log('  pnpm dev -- abilities pointbuy "<comma-separated scores>"');
+}
+
+const ABILITY_NAMES: AbilityName[] = ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA'];
+
+function isAbilityName(value: string): value is AbilityName {
+  return ABILITY_NAMES.includes(value as AbilityName);
+}
+
+function parseModifier(value: string | undefined): number {
+  if (!value) {
+    return 0;
+  }
+
+  if (value.startsWith('--')) {
+    return 0;
+  }
+
+  const cleaned = value.replace(/^\+/, '');
+  const parsed = Number.parseInt(cleaned, 10);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`Invalid modifier: ${value}`);
+  }
+  return parsed;
+}
+
+function formatModifier(value: number): string {
+  return value >= 0 ? `+${value}` : `${value}`;
+}
+
+function handleCheckCommand(type: 'check' | 'save', rawArgs: string[]): void {
+  if (rawArgs.length === 0) {
+    console.error('Missing ability for check.');
+    showUsage();
+    process.exit(1);
+  }
+
+  const abilityRaw = rawArgs[0].toUpperCase();
+  if (!isAbilityName(abilityRaw)) {
+    console.error(`Invalid ability name: ${rawArgs[0]}`);
+    process.exit(1);
+  }
+  const ability = abilityRaw as AbilityName;
+
+  let modifier = 0;
+  let startIndex = 1;
+  try {
+    modifier = parseModifier(rawArgs[1]);
+    if (rawArgs[1] && !rawArgs[1].startsWith('--')) {
+      startIndex = 2;
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(error.message);
+    }
+    process.exit(1);
+  }
+
+  let proficient = false;
+  let proficiencyBonus: number | undefined;
+  let advantage = false;
+  let disadvantage = false;
+  let dc: number | undefined;
+  let seed: string | undefined;
+
+  for (let i = startIndex; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+    const lower = arg.toLowerCase();
+
+    if (lower === '--proficient') {
+      proficient = true;
+      continue;
+    }
+
+    if (lower === '--adv' || lower === '--advantage') {
+      advantage = true;
+      continue;
+    }
+
+    if (lower === '--dis' || lower === '--disadvantage' || lower === '--disadv') {
+      disadvantage = true;
+      continue;
+    }
+
+    if (arg.startsWith('--pb=')) {
+      const value = Number.parseInt(arg.slice('--pb='.length), 10);
+      if (Number.isNaN(value)) {
+        console.error('Proficiency bonus must be a number.');
+        process.exit(1);
+      }
+      proficiencyBonus = value;
+      continue;
+    }
+
+    if (lower === '--pb') {
+      if (i + 1 >= rawArgs.length) {
+        console.error('Expected value after --pb.');
+        process.exit(1);
+      }
+      const value = Number.parseInt(rawArgs[i + 1], 10);
+      if (Number.isNaN(value)) {
+        console.error('Proficiency bonus must be a number.');
+        process.exit(1);
+      }
+      proficiencyBonus = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--dc=')) {
+      const value = Number.parseInt(arg.slice('--dc='.length), 10);
+      if (Number.isNaN(value)) {
+        console.error('DC must be an integer.');
+        process.exit(1);
+      }
+      dc = value;
+      continue;
+    }
+
+    if (lower === '--dc') {
+      if (i + 1 >= rawArgs.length) {
+        console.error('Expected value after --dc.');
+        process.exit(1);
+      }
+      const value = Number.parseInt(rawArgs[i + 1], 10);
+      if (Number.isNaN(value)) {
+        console.error('DC must be an integer.');
+        process.exit(1);
+      }
+      dc = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--seed=')) {
+      seed = arg.slice('--seed='.length);
+      continue;
+    }
+
+    if (lower === '--seed') {
+      if (i + 1 >= rawArgs.length) {
+        console.error('Expected value after --seed.');
+        process.exit(1);
+      }
+      seed = rawArgs[i + 1];
+      i += 1;
+      continue;
+    }
+
+    console.warn(`Ignoring unknown argument: ${arg}`);
+  }
+
+  if (advantage && disadvantage) {
+    console.error('Cannot roll with both advantage and disadvantage.');
+    process.exit(1);
+  }
+
+  const options = {
+    ability,
+    modifier,
+    proficient,
+    proficiencyBonus,
+    advantage,
+    disadvantage,
+    dc,
+    seed,
+  } as const;
+
+  const result = type === 'check' ? abilityCheck(options) : savingThrow(options);
+
+  const pbUsed = proficient
+    ? (Number.isFinite(proficiencyBonus) ? (proficiencyBonus as number) : 2)
+    : 0;
+  const pbLabel = proficient ? ` (proficient ${formatModifier(pbUsed)})` : '';
+  const modifierLabel = formatModifier(modifier);
+  const advLabel = advantage ? ' adv' : disadvantage ? ' dis' : '';
+  const dcLabel = typeof dc === 'number' ? ` vs DC ${dc}` : '';
+  const title = type === 'check' ? 'Ability Check' : 'Saving Throw';
+
+  console.log(
+    `${title}: ${abilityRaw} ${modifierLabel}${pbLabel}${advLabel}${dcLabel}`.trim(),
+  );
+  console.log(`Rolls: [${result.rolls.join(', ')}] → total ${result.total}`);
+  if (typeof result.success === 'boolean') {
+    console.log(`Result: ${result.success ? 'SUCCESS' : 'FAILURE'}`);
+  } else {
+    console.log(`Result: ${result.total}`);
+  }
+  process.exit(0);
 }
 
 const [, , ...argv] = process.argv;
@@ -75,6 +268,10 @@ if (command === 'roll') {
 
   console.log(`Rolls: [${result.rolls.join(', ')}] → total ${result.total}`);
   process.exit(0);
+}
+
+if (command === 'check' || command === 'save') {
+  handleCheckCommand(command, rest);
 }
 
 if (command === 'abilities') {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./dice": "./src/dice.ts",
-    "./abilityScores": "./src/abilityScores.ts"
+    "./abilityScores": "./src/abilityScores.ts",
+    "./checks": "./src/checks.ts"
   },
   "scripts": {
     "test": "vitest"

--- a/packages/core/src/checks.ts
+++ b/packages/core/src/checks.ts
@@ -1,0 +1,83 @@
+import { AbilityName } from './abilityScores.js';
+import { roll } from './dice.js';
+
+export interface CheckOptions {
+  ability: AbilityName;
+  modifier?: number;
+  proficient?: boolean;
+  proficiencyBonus?: number;
+  advantage?: boolean;
+  disadvantage?: boolean;
+  dc?: number;
+  seed?: string;
+}
+
+export interface CheckResult {
+  rolls: number[];
+  total: number;
+  success?: boolean;
+  expression: string;
+}
+
+function formatModifier(value: number): string {
+  if (value < 0) {
+    return `${value}`;
+  }
+  return `+${value}`;
+}
+
+function resolveCheck(opts: CheckOptions): CheckResult {
+  const {
+    modifier = 0,
+    proficient = false,
+    proficiencyBonus,
+    advantage = false,
+    disadvantage = false,
+    dc,
+    seed,
+  } = opts;
+
+  const pbValue = proficient ? (Number.isFinite(proficiencyBonus) ? proficiencyBonus! : 2) : 0;
+
+  const rollResult = roll('1d20', { advantage, disadvantage, seed });
+
+  const total = rollResult.total + modifier + pbValue;
+
+  const expressionParts = ['1d20'];
+  if (modifier !== 0) {
+    expressionParts.push(formatModifier(modifier));
+  }
+  if (pbValue !== 0) {
+    expressionParts.push(formatModifier(pbValue));
+  }
+
+  let expression = expressionParts.join('');
+  if (advantage) {
+    expression += ' adv';
+  } else if (disadvantage) {
+    expression += ' dis';
+  }
+  if (typeof dc === 'number') {
+    expression += ` vs DC ${dc}`;
+  }
+
+  const result: CheckResult = {
+    rolls: rollResult.rolls,
+    total,
+    expression,
+  };
+
+  if (typeof dc === 'number') {
+    result.success = total >= dc;
+  }
+
+  return result;
+}
+
+export function abilityCheck(opts: CheckOptions): CheckResult {
+  return resolveCheck(opts);
+}
+
+export function savingThrow(opts: CheckOptions): CheckResult {
+  return resolveCheck(opts);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,3 +13,5 @@ export type {
   AbilityRollOptions,
   PointBuyOptions,
 } from './abilityScores.js';
+export { abilityCheck, savingThrow } from './checks.js';
+export type { CheckOptions, CheckResult } from './checks.js';

--- a/packages/core/tests/checks.test.ts
+++ b/packages/core/tests/checks.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { abilityCheck, savingThrow } from '../src/checks.js';
+
+describe('abilityCheck', () => {
+  it('performs a simple ability check with modifiers', () => {
+    const result = abilityCheck({ ability: 'STR', modifier: 3, seed: 'simple' });
+
+    expect(result.rolls).toEqual([8]);
+    expect(result.total).toBe(11);
+    expect(result.expression).toBe('1d20+3');
+    expect(result.success).toBeUndefined();
+  });
+
+  it('adds proficiency bonuses when proficient', () => {
+    const result = abilityCheck({
+      ability: 'DEX',
+      modifier: 1,
+      proficient: true,
+      proficiencyBonus: 2,
+      seed: 'prof',
+    });
+
+    expect(result.rolls).toEqual([2]);
+    expect(result.total).toBe(5);
+    expect(result.expression).toBe('1d20+1+2');
+  });
+
+  it('supports advantage and disadvantage', () => {
+    const advantage = abilityCheck({ ability: 'DEX', advantage: true, seed: 'advantage' });
+    expect(advantage.rolls).toEqual([17, 12]);
+    expect(advantage.total).toBe(17);
+    expect(advantage.expression).toBe('1d20 adv');
+
+    const disadvantage = abilityCheck({ ability: 'DEX', disadvantage: true, seed: 'advantage' });
+    expect(disadvantage.rolls).toEqual([17, 12]);
+    expect(disadvantage.total).toBe(12);
+    expect(disadvantage.expression).toBe('1d20 dis');
+  });
+
+  it('evaluates success against a DC', () => {
+    const success = abilityCheck({ ability: 'STR', modifier: 1, dc: 15, seed: 'high' });
+    expect(success.total).toBe(15);
+    expect(success.success).toBe(true);
+    expect(success.expression).toBe('1d20+1 vs DC 15');
+
+    const failure = abilityCheck({ ability: 'STR', modifier: 1, dc: 12, seed: 'low' });
+    expect(failure.total).toBe(2);
+    expect(failure.success).toBe(false);
+    expect(failure.expression).toBe('1d20+1 vs DC 12');
+  });
+});
+
+describe('savingThrow', () => {
+  it('shares the same behavior as ability checks', () => {
+    const save = savingThrow({ ability: 'CON', modifier: 5, seed: 'high' });
+
+    expect(save.rolls).toEqual([14]);
+    expect(save.total).toBe(19);
+    expect(save.expression).toBe('1d20+5');
+    expect(save.success).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable ability check and saving throw utilities with modifiers, proficiency, advantage, and DC evaluation
- cover the new logic with unit tests to ensure deterministic seeded behavior
- extend the CLI with check/save commands and expose the new core entry points

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68de769d9be88327a26e50f56e8cdd1d