### PR TITLE
feat: add combat utilities and CLI commands

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -5,7 +5,11 @@ import {
   savingThrow,
   standardArray,
   validatePointBuy,
+  attackRoll,
+  damageRoll,
+  resolveAttack,
   type AbilityName,
+  type AttackRollResult,
 } from '@grimengine/core';
 
 function showUsage(): void {
@@ -13,6 +17,11 @@ function showUsage(): void {
   console.log('  pnpm dev -- roll "<expression>" [adv|dis] [--seed <value>]');
   console.log('  pnpm dev -- check <ability> [modifier] [--dc <n>] [--proficient] [--pb <n>] [--adv|--dis] [--seed <value>]');
   console.log('  pnpm dev -- save <ability> [modifier] [--dc <n>] [--proficient] [--pb <n>] [--adv|--dis] [--seed <value>]');
+  console.log('  pnpm dev -- attack [--mod <+n|-n>] [--proficient] [--pb <n>] [--adv|--dis] [--ac <n>] [--seed <value>]');
+  console.log('  pnpm dev -- damage "<expression>" [--crit] [--resist] [--vuln] [--seed <value>]');
+  console.log(
+    '  pnpm dev -- resolve --dmg "<expression>" [--mod <+n|-n>] [--proficient] [--pb <n>] [--adv|--dis] [--ac <n>] [--seed <value>] [--crit] [--resist] [--vuln] [--dmg-seed <value>]'
+  );
   console.log('  pnpm dev -- abilities roll [--seed <value>] [--count <n>] [--drop <n>] [--sort asc|desc|none]');
   console.log('  pnpm dev -- abilities standard');
   console.log('  pnpm dev -- abilities pointbuy "<comma-separated scores>"');
@@ -206,6 +215,393 @@ function handleCheckCommand(type: 'check' | 'save', rawArgs: string[]): void {
   process.exit(0);
 }
 
+function parseSignedInteger(value: string | undefined, label: string): number {
+  if (typeof value !== 'string') {
+    throw new Error(`Expected value for ${label}.`);
+  }
+
+  const cleaned = value.replace(/^\+/, '');
+  const parsed = Number.parseInt(cleaned, 10);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`${label} must be an integer.`);
+  }
+
+  return parsed;
+}
+
+function getAttackOutcome(attack: AttackRollResult): string | undefined {
+  if (attack.isCrit) {
+    return 'CRIT!';
+  }
+  if (attack.isFumble) {
+    return 'FUMBLE';
+  }
+  if (attack.hit === true) {
+    return 'HIT';
+  }
+  if (attack.hit === false) {
+    return 'MISS';
+  }
+  return undefined;
+}
+
+function handleAttackCommand(rawArgs: string[]): void {
+  let abilityMod = 0;
+  let proficient = false;
+  let proficiencyBonus: number | undefined;
+  let advantage = false;
+  let disadvantage = false;
+  let targetAC: number | undefined;
+  let seed: string | undefined;
+
+  try {
+    for (let i = 0; i < rawArgs.length; i += 1) {
+      const arg = rawArgs[i];
+      const lower = arg.toLowerCase();
+
+      if (lower === '--proficient') {
+        proficient = true;
+        continue;
+      }
+
+      if (lower === '--adv' || lower === '--advantage') {
+        advantage = true;
+        continue;
+      }
+
+      if (lower === '--dis' || lower === '--disadvantage' || lower === '--disadv') {
+        disadvantage = true;
+        continue;
+      }
+
+      if (arg.startsWith('--mod=')) {
+        abilityMod = parseSignedInteger(arg.slice('--mod='.length), '--mod');
+        continue;
+      }
+
+      if (lower === '--mod') {
+        abilityMod = parseSignedInteger(rawArgs[i + 1], '--mod');
+        i += 1;
+        continue;
+      }
+
+      if (arg.startsWith('--pb=')) {
+        proficiencyBonus = parseSignedInteger(arg.slice('--pb='.length), '--pb');
+        continue;
+      }
+
+      if (lower === '--pb') {
+        proficiencyBonus = parseSignedInteger(rawArgs[i + 1], '--pb');
+        i += 1;
+        continue;
+      }
+
+      if (arg.startsWith('--ac=')) {
+        targetAC = parseSignedInteger(arg.slice('--ac='.length), '--ac');
+        continue;
+      }
+
+      if (lower === '--ac') {
+        targetAC = parseSignedInteger(rawArgs[i + 1], '--ac');
+        i += 1;
+        continue;
+      }
+
+      if (arg.startsWith('--seed=')) {
+        seed = arg.slice('--seed='.length);
+        continue;
+      }
+
+      if (lower === '--seed') {
+        if (i + 1 >= rawArgs.length) {
+          throw new Error('Expected value after --seed.');
+        }
+        seed = rawArgs[i + 1];
+        i += 1;
+        continue;
+      }
+
+      console.warn(`Ignoring unknown argument: ${arg}`);
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(error.message);
+    }
+    process.exit(1);
+  }
+
+  if (advantage && disadvantage) {
+    console.error('Cannot roll with both advantage and disadvantage.');
+    process.exit(1);
+  }
+
+  const attack = attackRoll({
+    abilityMod,
+    proficient,
+    proficiencyBonus,
+    advantage,
+    disadvantage,
+    seed,
+    targetAC,
+  });
+
+  const outcome = getAttackOutcome(attack);
+
+  console.log(`Attack: ${attack.expression}`);
+  const rollsLine = `Rolls: [${attack.d20s.join(', ')}] → natural ${attack.natural} → total ${attack.total}`;
+  console.log(outcome ? `${rollsLine} → ${outcome}` : rollsLine);
+  if (outcome) {
+    console.log(`Result: ${outcome}`);
+  }
+
+  process.exit(0);
+}
+
+function handleDamageCommand(rawArgs: string[]): void {
+  if (rawArgs.length === 0) {
+    console.error('Missing damage expression.');
+    showUsage();
+    process.exit(1);
+  }
+
+  const [expression, ...rest] = rawArgs;
+  let crit = false;
+  let resistance = false;
+  let vulnerability = false;
+  let seed: string | undefined;
+
+  for (let i = 0; i < rest.length; i += 1) {
+    const arg = rest[i];
+    const lower = arg.toLowerCase();
+
+    if (lower === '--crit') {
+      crit = true;
+      continue;
+    }
+
+    if (lower === '--resist' || lower === '--resistance') {
+      resistance = true;
+      continue;
+    }
+
+    if (lower === '--vuln' || lower === '--vulnerability') {
+      vulnerability = true;
+      continue;
+    }
+
+    if (arg.startsWith('--seed=')) {
+      seed = arg.slice('--seed='.length);
+      continue;
+    }
+
+    if (lower === '--seed') {
+      if (i + 1 >= rest.length) {
+        console.error('Expected value after --seed.');
+        process.exit(1);
+      }
+      seed = rest[i + 1];
+      i += 1;
+      continue;
+    }
+
+    console.warn(`Ignoring unknown argument: ${arg}`);
+  }
+
+  const result = damageRoll({ expression, crit, resistance, vulnerability, seed });
+
+  console.log(`Damage: ${result.expression}`);
+  const parts = [`Rolls: [${result.rolls.join(', ')}]`];
+  if (result.critRolls && result.critRolls.length > 0) {
+    parts.push(`+ crit [${result.critRolls.join(', ')}]`);
+  }
+  parts.push(`→ base ${result.baseTotal}`);
+  parts.push(`→ final ${result.finalTotal}`);
+  console.log(parts.join(' '));
+
+  process.exit(0);
+}
+
+function handleResolveCommand(rawArgs: string[]): void {
+  let abilityMod = 0;
+  let proficient = false;
+  let proficiencyBonus: number | undefined;
+  let advantage = false;
+  let disadvantage = false;
+  let targetAC: number | undefined;
+  let seed: string | undefined;
+  let damageExpression: string | undefined;
+  let damageSeed: string | undefined;
+  let damageCrit = false;
+  let damageResistance = false;
+  let damageVulnerability = false;
+
+  try {
+    for (let i = 0; i < rawArgs.length; i += 1) {
+      const arg = rawArgs[i];
+      const lower = arg.toLowerCase();
+
+      if (arg.startsWith('--dmg=')) {
+        damageExpression = arg.slice('--dmg='.length);
+        continue;
+      }
+
+      if (lower === '--dmg') {
+        if (i + 1 >= rawArgs.length) {
+          throw new Error('Expected value after --dmg.');
+        }
+        damageExpression = rawArgs[i + 1];
+        i += 1;
+        continue;
+      }
+
+      if (arg.startsWith('--dmg-seed=')) {
+        damageSeed = arg.slice('--dmg-seed='.length);
+        continue;
+      }
+
+      if (lower === '--dmg-seed') {
+        if (i + 1 >= rawArgs.length) {
+          throw new Error('Expected value after --dmg-seed.');
+        }
+        damageSeed = rawArgs[i + 1];
+        i += 1;
+        continue;
+      }
+
+      if (lower === '--crit') {
+        damageCrit = true;
+        continue;
+      }
+
+      if (lower === '--resist' || lower === '--resistance') {
+        damageResistance = true;
+        continue;
+      }
+
+      if (lower === '--vuln' || lower === '--vulnerability') {
+        damageVulnerability = true;
+        continue;
+      }
+
+      if (lower === '--proficient') {
+        proficient = true;
+        continue;
+      }
+
+      if (lower === '--adv' || lower === '--advantage') {
+        advantage = true;
+        continue;
+      }
+
+      if (lower === '--dis' || lower === '--disadvantage' || lower === '--disadv') {
+        disadvantage = true;
+        continue;
+      }
+
+      if (arg.startsWith('--mod=')) {
+        abilityMod = parseSignedInteger(arg.slice('--mod='.length), '--mod');
+        continue;
+      }
+
+      if (lower === '--mod') {
+        abilityMod = parseSignedInteger(rawArgs[i + 1], '--mod');
+        i += 1;
+        continue;
+      }
+
+      if (arg.startsWith('--pb=')) {
+        proficiencyBonus = parseSignedInteger(arg.slice('--pb='.length), '--pb');
+        continue;
+      }
+
+      if (lower === '--pb') {
+        proficiencyBonus = parseSignedInteger(rawArgs[i + 1], '--pb');
+        i += 1;
+        continue;
+      }
+
+      if (arg.startsWith('--ac=')) {
+        targetAC = parseSignedInteger(arg.slice('--ac='.length), '--ac');
+        continue;
+      }
+
+      if (lower === '--ac') {
+        targetAC = parseSignedInteger(rawArgs[i + 1], '--ac');
+        i += 1;
+        continue;
+      }
+
+      if (arg.startsWith('--seed=')) {
+        seed = arg.slice('--seed='.length);
+        continue;
+      }
+
+      if (lower === '--seed') {
+        if (i + 1 >= rawArgs.length) {
+          throw new Error('Expected value after --seed.');
+        }
+        seed = rawArgs[i + 1];
+        i += 1;
+        continue;
+      }
+
+      console.warn(`Ignoring unknown argument: ${arg}`);
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(error.message);
+    }
+    process.exit(1);
+  }
+
+  if (!damageExpression) {
+    console.error('Missing damage expression. Provide --dmg "<expression>".');
+    process.exit(1);
+  }
+
+  if (advantage && disadvantage) {
+    console.error('Cannot roll with both advantage and disadvantage.');
+    process.exit(1);
+  }
+
+  const result = resolveAttack({
+    abilityMod,
+    proficient,
+    proficiencyBonus,
+    advantage,
+    disadvantage,
+    seed,
+    targetAC,
+    damage: {
+      expression: damageExpression,
+      crit: damageCrit,
+      resistance: damageResistance,
+      vulnerability: damageVulnerability,
+      seed: damageSeed,
+    },
+  });
+
+  const { attack, damage } = result;
+  const outcome = getAttackOutcome(attack);
+
+  console.log(`Attack: ${attack.expression}`);
+  const rollsLine = `Rolls: [${attack.d20s.join(', ')}] → natural ${attack.natural} → total ${attack.total}`;
+  console.log(outcome ? `${rollsLine} → ${outcome}` : rollsLine);
+
+  if (damage) {
+    console.log(`Damage: ${damage.expression}`);
+    const parts = [`Rolls: [${damage.rolls.join(', ')}]`];
+    if (damage.critRolls && damage.critRolls.length > 0) {
+      parts.push(`+ crit [${damage.critRolls.join(', ')}]`);
+    }
+    parts.push(`→ base ${damage.baseTotal}`);
+    parts.push(`→ final ${damage.finalTotal}`);
+    console.log(parts.join(' '));
+  }
+
+  process.exit(0);
+}
+
 const [, , ...argv] = process.argv;
 const args = argv[0] === '--' ? argv.slice(1) : argv;
 
@@ -272,6 +668,18 @@ if (command === 'roll') {
 
 if (command === 'check' || command === 'save') {
   handleCheckCommand(command, rest);
+}
+
+if (command === 'attack') {
+  handleAttackCommand(rest);
+}
+
+if (command === 'damage') {
+  handleDamageCommand(rest);
+}
+
+if (command === 'resolve') {
+  handleResolveCommand(rest);
 }
 
 if (command === 'abilities') {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,8 @@
     ".": "./src/index.ts",
     "./dice": "./src/dice.ts",
     "./abilityScores": "./src/abilityScores.ts",
-    "./checks": "./src/checks.ts"
+    "./checks": "./src/checks.ts",
+    "./combat": "./src/combat.ts"
   },
   "scripts": {
     "test": "vitest"

--- a/packages/core/src/combat.ts
+++ b/packages/core/src/combat.ts
@@ -1,0 +1,269 @@
+import { roll } from './dice.js';
+
+export interface AttackRollOptions {
+  abilityMod?: number;
+  proficient?: boolean;
+  proficiencyBonus?: number;
+  advantage?: boolean;
+  disadvantage?: boolean;
+  seed?: string;
+  targetAC?: number;
+}
+
+export interface AttackRollResult {
+  d20s: number[];
+  natural: number;
+  total: number;
+  isCrit: boolean;
+  isFumble: boolean;
+  hit?: boolean;
+  expression: string;
+}
+
+export interface DamageRollOptions {
+  expression: string;
+  crit?: boolean;
+  resistance?: boolean;
+  vulnerability?: boolean;
+  seed?: string;
+}
+
+export interface DamageRollResult {
+  rolls: number[];
+  critRolls?: number[];
+  baseTotal: number;
+  finalTotal: number;
+  expression: string;
+}
+
+export interface ResolveAttackOptions extends AttackRollOptions {
+  damage: DamageRollOptions;
+}
+
+export interface ResolveAttackResult {
+  attack: AttackRollResult;
+  damage?: DamageRollResult;
+}
+
+type ParsedTerm =
+  | { type: 'dice'; sign: 1 | -1; count: number; sides: number }
+  | { type: 'number'; sign: 1 | -1; value: number };
+
+const TERM_PATTERN = /[+-]?[^+-]+/g;
+const DEFAULT_PROFICIENCY_BONUS = 2;
+
+function parseModifierString(value: number): string {
+  return value >= 0 ? `+${value}` : `${value}`;
+}
+
+function normalizeExpression(expr: string): { terms: ParsedTerm[]; normalized: string } {
+  const compact = expr.replace(/\s+/g, '');
+  if (!compact) {
+    throw new Error('Empty damage expression');
+  }
+
+  const tokens = compact.match(TERM_PATTERN);
+  if (!tokens) {
+    throw new Error(`Invalid damage expression: ${expr}`);
+  }
+
+  const terms: ParsedTerm[] = [];
+
+  tokens.forEach((rawToken) => {
+    let token = rawToken;
+    let sign: 1 | -1 = 1;
+
+    if (token.startsWith('+')) {
+      token = token.slice(1);
+    } else if (token.startsWith('-')) {
+      sign = -1;
+      token = token.slice(1);
+    }
+
+    if (!token) {
+      throw new Error(`Invalid token in damage expression: ${rawToken}`);
+    }
+
+    const diceMatch = token.match(/^(\d*)d(\d+)$/i);
+    if (diceMatch) {
+      const [, countStr, sidesStr] = diceMatch;
+      const count = countStr ? Number.parseInt(countStr, 10) : 1;
+      const sides = Number.parseInt(sidesStr, 10);
+
+      if (!Number.isFinite(count) || count < 1) {
+        throw new Error(`Invalid dice count in token: ${rawToken}`);
+      }
+
+      if (!Number.isFinite(sides) || sides < 2) {
+        throw new Error(`Invalid dice sides in token: ${rawToken}`);
+      }
+
+      terms.push({ type: 'dice', sign, count, sides });
+      return;
+    }
+
+    const value = Number.parseInt(token, 10);
+    if (!Number.isFinite(value)) {
+      throw new Error(`Invalid modifier in damage expression: ${rawToken}`);
+    }
+
+    terms.push({ type: 'number', sign, value });
+  });
+
+  const normalized = terms
+    .map((term, index) => {
+      const body = term.type === 'dice' ? `${term.count}d${term.sides}` : `${term.value}`;
+      if (index === 0) {
+        return term.sign === -1 ? `-${body}` : body;
+      }
+      const prefix = term.sign === -1 ? '-' : '+';
+      return `${prefix}${body}`;
+    })
+    .join('');
+
+  return { terms, normalized };
+}
+
+function computeModifierTotal(terms: ParsedTerm[]): number {
+  return terms.reduce((sum, term) => {
+    if (term.type === 'number') {
+      return sum + term.sign * term.value;
+    }
+    return sum;
+  }, 0);
+}
+
+function formatDamageExpression(base: string, opts: DamageRollOptions): string {
+  const tags: string[] = [];
+  if (opts.crit) {
+    tags.push('crit');
+  }
+  if (opts.resistance) {
+    tags.push('resist');
+  }
+  if (opts.vulnerability) {
+    tags.push('vuln');
+  }
+  return tags.length > 0 ? `${base} (${tags.join(', ')})` : base;
+}
+
+export function attackRoll(opts: AttackRollOptions): AttackRollResult {
+  if (opts.advantage && opts.disadvantage) {
+    throw new Error('Cannot roll with both advantage and disadvantage');
+  }
+
+  const abilityMod = opts.abilityMod ?? 0;
+  const proficiency = opts.proficient ? opts.proficiencyBonus ?? DEFAULT_PROFICIENCY_BONUS : 0;
+  const totalModifier = abilityMod + proficiency;
+
+  const rollResult = roll('1d20', {
+    advantage: opts.advantage,
+    disadvantage: opts.disadvantage,
+    seed: opts.seed,
+  });
+
+  const d20s = [...rollResult.rolls];
+  const natural = opts.advantage
+    ? Math.max(...d20s)
+    : opts.disadvantage
+    ? Math.min(...d20s)
+    : d20s[0];
+
+  const total = natural + totalModifier;
+  const isCrit = natural === 20;
+  const isFumble = natural === 1;
+
+  let hit: boolean | undefined;
+  if (typeof opts.targetAC === 'number') {
+    hit = !isFumble && (isCrit || total >= opts.targetAC);
+  }
+
+  const modifierLabel = totalModifier !== 0 ? parseModifierString(totalModifier) : '';
+  const advLabel = opts.advantage ? ' adv' : opts.disadvantage ? ' dis' : '';
+  const acLabel = typeof opts.targetAC === 'number' ? ` vs AC ${opts.targetAC}` : '';
+  const expression = `1d20${modifierLabel}${advLabel}${acLabel}`.trim();
+
+  return {
+    d20s,
+    natural,
+    total,
+    isCrit,
+    isFumble,
+    hit,
+    expression,
+  };
+}
+
+export function damageRoll(opts: DamageRollOptions): DamageRollResult {
+  const { terms, normalized } = normalizeExpression(opts.expression);
+  const baseRoll = roll(normalized, { seed: opts.seed });
+
+  const rolls = [...baseRoll.rolls];
+  let diceIndex = 0;
+  let signedDiceTotal = 0;
+
+  terms.forEach((term) => {
+    if (term.type === 'dice') {
+      for (let i = 0; i < term.count; i += 1) {
+        const value = rolls[diceIndex];
+        if (typeof value !== 'number') {
+          throw new Error('Dice roll mismatch in damageRoll');
+        }
+        signedDiceTotal += term.sign * value;
+        diceIndex += 1;
+      }
+    }
+  });
+
+  const modifierTotal = computeModifierTotal(terms);
+
+  let critRolls: number[] | undefined;
+  let critDiceTotal = 0;
+  if (opts.crit) {
+    const diceTerms = terms.filter((term): term is Extract<ParsedTerm, { type: 'dice' }> => term.type === 'dice');
+    if (diceTerms.length > 0) {
+      const critTokens = diceTerms.map((term, index) => {
+        const prefix = index === 0 ? (term.sign === -1 ? '-' : '') : term.sign === -1 ? '-' : '+';
+        return `${prefix}${term.count}d${term.sides}`;
+      });
+      const critExpression = critTokens.join('');
+      const critSeed = opts.seed ? `${opts.seed}:crit` : undefined;
+      const critResult = roll(critExpression, { seed: critSeed });
+      critRolls = [...critResult.rolls];
+      critDiceTotal = critResult.total;
+    }
+  }
+
+  const baseTotal = signedDiceTotal + critDiceTotal + modifierTotal;
+
+  let finalTotal = baseTotal;
+  if (opts.resistance) {
+    finalTotal = Math.floor(finalTotal / 2);
+  }
+  if (opts.vulnerability) {
+    finalTotal *= 2;
+  }
+  finalTotal = Math.max(0, Math.floor(finalTotal));
+
+  return {
+    rolls,
+    critRolls,
+    baseTotal,
+    finalTotal,
+    expression: formatDamageExpression(baseRoll.expression, opts),
+  };
+}
+
+export function resolveAttack(opts: ResolveAttackOptions): ResolveAttackResult {
+  const attack = attackRoll(opts);
+
+  const shouldRollDamage =
+    attack.isCrit || attack.hit === true || (typeof attack.hit === 'undefined' && !attack.isFumble);
+
+  if (!shouldRollDamage) {
+    return { attack };
+  }
+
+  const damage = damageRoll({ ...opts.damage, crit: attack.isCrit || opts.damage.crit });
+  return { attack, damage };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,3 +15,12 @@ export type {
 } from './abilityScores.js';
 export { abilityCheck, savingThrow } from './checks.js';
 export type { CheckOptions, CheckResult } from './checks.js';
+export { attackRoll, damageRoll, resolveAttack } from './combat.js';
+export type {
+  AttackRollOptions,
+  AttackRollResult,
+  DamageRollOptions,
+  DamageRollResult,
+  ResolveAttackOptions,
+  ResolveAttackResult,
+} from './combat.js';

--- a/packages/core/tests/combat.test.ts
+++ b/packages/core/tests/combat.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { attackRoll, damageRoll, resolveAttack } from '../src/combat.js';
+
+describe('attackRoll', () => {
+  it('applies ability and proficiency modifiers', () => {
+    const result = attackRoll({
+      abilityMod: 3,
+      proficient: true,
+      proficiencyBonus: 2,
+      seed: 'attack-basic',
+      targetAC: 15,
+    });
+
+    expect(result.d20s).toEqual([18]);
+    expect(result.natural).toBe(18);
+    expect(result.total).toBe(23);
+    expect(result.hit).toBe(true);
+    expect(result.expression).toBe('1d20+5 vs AC 15');
+  });
+
+  it('supports advantage and disadvantage', () => {
+    const advantage = attackRoll({ advantage: true, seed: 'adv-seed' });
+    expect(advantage.d20s).toEqual([20, 13]);
+    expect(advantage.natural).toBe(20);
+    expect(advantage.total).toBe(20);
+    expect(advantage.expression).toBe('1d20 adv');
+
+    const disadvantage = attackRoll({ disadvantage: true, seed: 'adv-seed' });
+    expect(disadvantage.d20s).toEqual([20, 13]);
+    expect(disadvantage.natural).toBe(13);
+    expect(disadvantage.total).toBe(13);
+    expect(disadvantage.expression).toBe('1d20 dis');
+  });
+
+  it('detects critical hits and fumbles', () => {
+    const crit = attackRoll({ advantage: true, seed: 'adv-seed', targetAC: 30 });
+    expect(crit.isCrit).toBe(true);
+    expect(crit.hit).toBe(true);
+
+    const fumble = attackRoll({ seed: 'seed-1', targetAC: 5 });
+    expect(fumble.isFumble).toBe(true);
+    expect(fumble.hit).toBe(false);
+  });
+});
+
+describe('damageRoll', () => {
+  it('doubles dice (not modifiers) on critical hits', () => {
+    const result = damageRoll({ expression: '1d8+3', crit: true, seed: 'damage-basic' });
+
+    expect(result.rolls).toEqual([3]);
+    expect(result.critRolls).toEqual([4]);
+    expect(result.baseTotal).toBe(10);
+    expect(result.finalTotal).toBe(10);
+    expect(result.expression).toBe('1d8+3 (crit)');
+  });
+
+  it('applies resistance and vulnerability', () => {
+    const resistance = damageRoll({
+      expression: '2d6+4',
+      resistance: true,
+      seed: 'damage-resist',
+    });
+    expect(resistance.baseTotal).toBe(14);
+    expect(resistance.finalTotal).toBe(7);
+    expect(resistance.expression).toBe('2d6+4 (resist)');
+
+    const vulnerability = damageRoll({
+      expression: '1d10+2',
+      vulnerability: true,
+      seed: 'damage-vuln',
+    });
+    expect(vulnerability.baseTotal).toBe(6);
+    expect(vulnerability.finalTotal).toBe(12);
+    expect(vulnerability.expression).toBe('1d10+2 (vuln)');
+  });
+});
+
+describe('resolveAttack', () => {
+  it('returns attack only when the attack misses', () => {
+    const result = resolveAttack({
+      seed: 'seed-1',
+      targetAC: 10,
+      damage: { expression: '1d8+3', seed: 'damage-basic' },
+    });
+
+    expect(result.attack.hit).toBe(false);
+    expect(result.damage).toBeUndefined();
+  });
+
+  it('returns damage on a normal hit', () => {
+    const result = resolveAttack({
+      seed: 'attack-basic',
+      abilityMod: 2,
+      targetAC: 15,
+      damage: { expression: '1d8+3', seed: 'damage-basic' },
+    });
+
+    expect(result.attack.hit).toBe(true);
+    expect(result.attack.isCrit).toBe(false);
+    expect(result.damage).toBeDefined();
+    expect(result.damage?.baseTotal).toBe(6);
+    expect(result.damage?.finalTotal).toBe(6);
+  });
+
+  it('doubles damage dice on critical hits', () => {
+    const result = resolveAttack({
+      advantage: true,
+      seed: 'adv-seed',
+      targetAC: 25,
+      damage: { expression: '1d8+3', seed: 'damage-basic' },
+    });
+
+    expect(result.attack.isCrit).toBe(true);
+    expect(result.damage).toBeDefined();
+    expect(result.damage?.critRolls).toEqual([4]);
+    expect(result.damage?.baseTotal).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
- add core combat helpers for attack, damage, and combined resolution rolls
- cover new combat utilities with deterministic vitest cases
- extend the CLI with attack, damage, and resolve commands to exercise the API

## Testing
- pnpm test
- pnpm dev -- attack --mod +7 --pb 2 --proficient --adv --ac 15 --seed attack-basic
- pnpm dev -- damage "1d8+3" --crit --seed damage-basic
- pnpm dev -- resolve --mod +5 --ac 14 --dmg "1d8+3" --adv --seed adv-seed --dmg-seed damage-basic


------
https://chatgpt.com/codex/tasks/task_e_68de7ce1cd7c8327afddc3a15eb23ccf