### PR TITLE
fix(cli): persist loaded character in module scope

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -61,7 +61,7 @@ function isAbilityName(value: string): value is AbilityName {
 
 setCharacterWeaponLookup(getWeaponByName);
 
-let loadedCharacter: Character | undefined;
+let CURRENT_CHARACTER: Character | null = null;
 
 function parseModifier(value: string | undefined): number {
   if (!value) {
@@ -114,11 +114,11 @@ function formatWeaponProperties(weapon: Weapon): string {
 }
 
 function requireLoadedCharacter(): Character {
-  if (!loadedCharacter) {
+  if (!CURRENT_CHARACTER) {
     console.error('No character loaded. Use `pnpm dev -- character load "<path.json>"` first.');
     process.exit(1);
   }
-  return loadedCharacter;
+  return CURRENT_CHARACTER;
 }
 
 function handleCharacterLoadCommand(path: string | undefined): void {
@@ -159,7 +159,7 @@ function handleCharacterLoadCommand(path: string | undefined): void {
     };
 
     const pb = proficiencyBonusForLevel(character.level);
-    loadedCharacter = character;
+    CURRENT_CHARACTER = character;
     console.log(`Loaded character ${character.name} (lvl ${character.level}). PB ${formatModifier(pb)}`);
     process.exit(0);
   } catch (error) {

--- a/example/fighter.json
+++ b/example/fighter.json
@@ -1,0 +1,10 @@
+{
+  "name": "Aerin",
+  "level": 3,
+  "abilities": { "STR": 16, "DEX": 14, "CON": 12, "INT": 10, "WIS": 10, "CHA": 8 },
+  "proficiencies": {
+    "weapons": { "martial": true },
+    "saves": ["STR", "CON"],
+    "skills": ["Athletics", "Perception"]
+  }
+}

--- a/packages/adapters/rules-srd/src/index.ts
+++ b/packages/adapters/rules-srd/src/index.ts
@@ -1,1 +1,1 @@
-export { WEAPONS } from './weapons.js';
+export { WEAPONS, getWeaponByName } from './weapons.js';


### PR DESCRIPTION
## Summary
- ensure the CLI stores the loaded character in a module-level CURRENT_CHARACTER slot
- provide a sample fighter.json character for manual testing
- re-export getWeaponByName from the rules SRD adapter package

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb6328e348327914140a18f823c8b