### PR TITLE
feat(core): skills layer (mapping, proficiency/expertise) + passive perception + CLI

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,9 +43,13 @@ export {
   abilityMods,
   isProficientSave,
   isProficientSkill,
+  skillAbility,
+  hasExpertise,
   characterAbilityCheck,
   characterSavingThrow,
+  characterSkillCheck,
   characterWeaponAttack,
+  passivePerception,
   setCharacterWeaponLookup,
 } from './character.js';
 export type {
@@ -54,3 +58,4 @@ export type {
   CharacterProficiencies,
   SkillName,
 } from './character.js';
+export { SKILL_ABILITY } from './skills.js';

--- a/packages/core/src/skills.ts
+++ b/packages/core/src/skills.ts
@@ -1,0 +1,23 @@
+import type { AbilityName } from './abilityScores.js';
+import type { SkillName } from './character.js';
+
+export const SKILL_ABILITY: Record<SkillName, AbilityName> = {
+  Acrobatics: 'DEX',
+  'Animal Handling': 'WIS',
+  Arcana: 'INT',
+  Athletics: 'STR',
+  Deception: 'CHA',
+  History: 'INT',
+  Insight: 'WIS',
+  Intimidation: 'CHA',
+  Investigation: 'INT',
+  Medicine: 'WIS',
+  Nature: 'INT',
+  Perception: 'WIS',
+  Performance: 'CHA',
+  Persuasion: 'CHA',
+  Religion: 'INT',
+  'Sleight of Hand': 'DEX',
+  Stealth: 'DEX',
+  Survival: 'WIS',
+};

--- a/packages/core/tests/skills.test.ts
+++ b/packages/core/tests/skills.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  characterSkillCheck,
+  passivePerception,
+  skillAbility,
+  type Character,
+} from '../src/character.js';
+
+function buildCharacter(proficiencies: Character['proficiencies'] = {}): Character {
+  return {
+    name: 'Tester',
+    level: 5,
+    abilities: {
+      STR: 10,
+      DEX: 10,
+      CON: 10,
+      INT: 10,
+      WIS: 14,
+      CHA: 10,
+    },
+    proficiencies,
+  };
+}
+
+describe('skillAbility', () => {
+  it('maps skills to their governing abilities', () => {
+    expect(skillAbility('Athletics')).toBe('STR');
+    expect(skillAbility('Stealth')).toBe('DEX');
+    expect(skillAbility('Perception')).toBe('WIS');
+  });
+});
+
+describe('characterSkillCheck', () => {
+  it('applies proficiency and expertise modifiers', () => {
+    const base = buildCharacter();
+    const proficient = buildCharacter({ skills: ['Perception'] });
+    const expert = buildCharacter({ skills: ['Perception'], expertise: ['Perception'] });
+
+    const seed = 'skill-check';
+
+    const baseResult = characterSkillCheck(base, 'Perception', { seed });
+    const profResult = characterSkillCheck(proficient, 'Perception', { seed });
+    const expertResult = characterSkillCheck(expert, 'Perception', { seed });
+
+    expect(profResult.rolls).toEqual(baseResult.rolls);
+    expect(expertResult.rolls).toEqual(baseResult.rolls);
+
+    expect(profResult.total - baseResult.total).toBe(3);
+    expect(expertResult.total - baseResult.total).toBe(6);
+  });
+
+  it('is deterministic when provided a seed', () => {
+    const character = buildCharacter({ skills: ['Stealth'] });
+    const first = characterSkillCheck(character, 'Stealth', { seed: 'deterministic' });
+    const second = characterSkillCheck(character, 'Stealth', { seed: 'deterministic' });
+
+    expect(second).toEqual(first);
+  });
+});
+
+describe('passivePerception', () => {
+  it('computes passive perception from ability and proficiency', () => {
+    const base = buildCharacter();
+    const proficient = buildCharacter({ skills: ['Perception'] });
+    const expert = buildCharacter({ skills: ['Perception'], expertise: ['Perception'] });
+
+    expect(passivePerception(base)).toBe(12);
+    expect(passivePerception(proficient)).toBe(15);
+    expect(passivePerception(expert)).toBe(18);
+  });
+});


### PR DESCRIPTION
Add a skills system to @grimengine/core:
- Map each 5e skill to its governing ability
- Skill checks with proficiency and expertise (2× PB)
- Expose passive Perception on character summary
- CLI: run skill checks and list skills

This builds on existing checks/character modules; keep it small and composable.

------
https://chatgpt.com/codex/tasks/task_e_68dec3003a488327b4f5275cc35fe355