### PR TITLE
feat: derive player stats from character equipment

### DIFF
--- a/packages/adapters/rules-srd/package.json
+++ b/packages/adapters/rules-srd/package.json
@@ -6,6 +6,7 @@
   "main": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./weapons": "./src/weapons.ts"
+    "./weapons": "./src/weapons.ts",
+    "./armor": "./src/armor.ts"
   }
 }

--- a/packages/adapters/rules-srd/src/armor.ts
+++ b/packages/adapters/rules-srd/src/armor.ts
@@ -1,0 +1,34 @@
+export type ArmorCategory = 'unarmored' | 'light' | 'medium' | 'heavy' | 'shield';
+
+export interface Armor {
+  name: string;
+  category: Exclude<ArmorCategory, 'shield'>;
+  baseAC: number;
+  dexCap?: number;
+}
+
+export interface Shield {
+  name: string;
+  bonusAC: number;
+}
+
+export const ARMORS: Armor[] = [
+  { name: 'Padded', category: 'light', baseAC: 11 },
+  { name: 'Leather', category: 'light', baseAC: 11 },
+  { name: 'Studded Leather', category: 'light', baseAC: 12 },
+  { name: 'Hide', category: 'medium', baseAC: 12, dexCap: 2 },
+  { name: 'Chain Shirt', category: 'medium', baseAC: 13, dexCap: 2 },
+  { name: 'Scale Mail', category: 'medium', baseAC: 14, dexCap: 2 },
+  { name: 'Breastplate', category: 'medium', baseAC: 14, dexCap: 2 },
+  { name: 'Half Plate', category: 'medium', baseAC: 15, dexCap: 2 },
+  { name: 'Ring Mail', category: 'heavy', baseAC: 14, dexCap: 0 },
+  { name: 'Chain Mail', category: 'heavy', baseAC: 16, dexCap: 0 },
+  { name: 'Splint', category: 'heavy', baseAC: 17, dexCap: 0 },
+  { name: 'Plate', category: 'heavy', baseAC: 18, dexCap: 0 },
+];
+
+export const SHIELD: Shield = { name: 'Shield', bonusAC: 2 };
+
+export function getArmorByName(name: string): Armor | undefined {
+  return ARMORS.find((armor) => armor.name.toLowerCase() === name.toLowerCase());
+}

--- a/packages/adapters/rules-srd/src/index.ts
+++ b/packages/adapters/rules-srd/src/index.ts
@@ -1,2 +1,3 @@
 export { WEAPONS, getWeaponByName } from './weapons.js';
 export { MONSTERS, getMonsterByName } from './monsters.js';
+export { ARMORS, SHIELD, getArmorByName } from './armor.js';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,9 @@
     "./weapons": "./src/weapons.ts"
   },
   "scripts": {
-    "test": "vitest"
+    "test": "vitest --config vitest.config.ts"
+  },
+  "dependencies": {
+    "@grimengine/rules-srd": "workspace:*"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,9 @@ export {
   abilityMod,
   proficiencyBonusForLevel,
   abilityMods,
+  derivedAC,
+  derivedMaxHP,
+  derivedDefaultWeaponProfile,
   isProficientSave,
   isProficientSkill,
   skillAbility,
@@ -51,11 +54,13 @@ export {
   characterWeaponAttack,
   passivePerception,
   setCharacterWeaponLookup,
+  setCharacterArmorData,
 } from './character.js';
 export type {
   Character,
   CharacterAbilityScores,
   CharacterProficiencies,
+  Equipped,
   SkillName,
 } from './character.js';
 export { SKILL_ABILITY } from './skills.js';

--- a/packages/core/tests/derived.test.ts
+++ b/packages/core/tests/derived.test.ts
@@ -1,0 +1,155 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  derivedAC,
+  derivedMaxHP,
+  derivedDefaultWeaponProfile,
+  setCharacterArmorData,
+  setCharacterWeaponLookup,
+  type Character,
+} from '../src/character.js';
+import type { Weapon } from '../src/weapons.js';
+
+const BASE_CHARACTER: Character = {
+  name: 'Hero',
+  level: 1,
+  abilities: {
+    STR: 10,
+    DEX: 10,
+    CON: 10,
+    INT: 10,
+    WIS: 10,
+    CHA: 10,
+  },
+};
+
+const ARMOR_FIXTURES = new Map<string, { category: 'light' | 'medium' | 'heavy'; baseAC: number; dexCap?: number }>([
+  ['scale mail', { category: 'medium', baseAC: 14, dexCap: 2 }],
+  ['plate', { category: 'heavy', baseAC: 18 }],
+  ['padded', { category: 'light', baseAC: 11 }],
+]);
+
+const WEAPON_FIXTURES = new Map<string, Weapon>([
+  [
+    'longsword',
+    {
+      name: 'Longsword',
+      category: 'martial',
+      type: 'melee',
+      damage: { expression: '1d8+0', type: 'slashing' },
+      versatile: { expression: '1d10+0' },
+    },
+  ],
+]);
+
+beforeAll(() => {
+  setCharacterArmorData((name) => ARMOR_FIXTURES.get(name.toLowerCase()), 2);
+  setCharacterWeaponLookup((name) => WEAPON_FIXTURES.get(name.toLowerCase()));
+});
+
+afterAll(() => {
+  setCharacterArmorData(undefined);
+  setCharacterWeaponLookup(undefined);
+});
+
+describe('derivedAC', () => {
+  it('calculates unarmored AC with and without a shield', () => {
+    const character: Character = {
+      ...BASE_CHARACTER,
+      abilities: { ...BASE_CHARACTER.abilities, DEX: 14 },
+    };
+
+    expect(derivedAC(character)).toBe(12);
+
+    const withShield: Character = {
+      ...character,
+      equipped: { shield: true },
+    };
+
+    expect(derivedAC(withShield)).toBe(14);
+  });
+
+  it('applies dexterity caps for medium armor and ignores dexterity for heavy armor', () => {
+    const medium: Character = {
+      ...BASE_CHARACTER,
+      abilities: { ...BASE_CHARACTER.abilities, DEX: 16 },
+      equipped: { armor: 'Scale Mail' },
+    };
+
+    expect(derivedAC(medium)).toBe(16);
+
+    const heavy: Character = {
+      ...medium,
+      abilities: { ...medium.abilities, DEX: 20 },
+      equipped: { armor: 'Plate' },
+    };
+
+    expect(derivedAC(heavy)).toBe(18);
+  });
+});
+
+describe('derivedMaxHP', () => {
+  it('uses full hit die at level 1', () => {
+    const character: Character = {
+      ...BASE_CHARACTER,
+      abilities: { ...BASE_CHARACTER.abilities, CON: 14 },
+      equipped: { hitDie: 'd10' },
+    };
+
+    expect(derivedMaxHP(character)).toBe(12);
+  });
+
+  it('adds average hit die and constitution for higher levels', () => {
+    const character: Character = {
+      ...BASE_CHARACTER,
+      level: 3,
+      abilities: { ...BASE_CHARACTER.abilities, CON: 14 },
+      equipped: { hitDie: 'd10' },
+    };
+
+    expect(derivedMaxHP(character)).toBe(28);
+  });
+});
+
+describe('derivedDefaultWeaponProfile', () => {
+  it('derives proficiency bonus and ability modifiers for equipped weapons', () => {
+    const character: Character = {
+      ...BASE_CHARACTER,
+      level: 3,
+      abilities: { ...BASE_CHARACTER.abilities, STR: 16 },
+      proficiencies: { weapons: { martial: true } },
+      equipped: { weapon: 'Longsword' },
+    };
+
+    const profile = derivedDefaultWeaponProfile(character);
+    expect(profile).not.toBeNull();
+    expect(profile?.name).toBe('Longsword');
+    expect(profile?.attackMod).toBe(5);
+    expect(profile?.damageExpr).toBe('1d8+3');
+    expect(profile?.versatileExpr).toBe('1d10+3');
+  });
+
+  it('omits proficiency bonus when the character lacks proficiency', () => {
+    const character: Character = {
+      ...BASE_CHARACTER,
+      level: 3,
+      abilities: { ...BASE_CHARACTER.abilities, STR: 16 },
+      proficiencies: { weapons: { simple: true } },
+      equipped: { weapon: 'Longsword' },
+    };
+
+    const profile = derivedDefaultWeaponProfile(character);
+    expect(profile).not.toBeNull();
+    expect(profile?.attackMod).toBe(3);
+    expect(profile?.damageExpr).toBe('1d8+3');
+  });
+
+  it('returns null when no weapon is equipped', () => {
+    const character: Character = {
+      ...BASE_CHARACTER,
+      level: 3,
+    };
+
+    expect(derivedDefaultWeaponProfile(character)).toBeNull();
+  });
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PACKAGE_DIR = fileURLToPath(new URL('.', import.meta.url));
+const ROOT_DIR = resolve(PACKAGE_DIR, '..', '..');
+const RULES_SRD_SRC = resolve(ROOT_DIR, 'packages/adapters/rules-srd/src');
+
+export default defineConfig({
+  root: PACKAGE_DIR,
+  resolve: {
+    alias: {
+      '@grimengine/rules-srd': resolve(RULES_SRD_SRC, 'index.ts'),
+      '@grimengine/rules-srd/*': `${RULES_SRD_SRC}/*`,
+      '@grimengine/rules-srd/armor': resolve(RULES_SRD_SRC, 'armor.ts'),
+      '@grimengine/rules-srd/weapons': resolve(RULES_SRD_SRC, 'weapons.ts'),
+      '@grimengine/rules-srd/monsters': resolve(RULES_SRD_SRC, 'monsters.ts'),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.6.1)(tsx@4.20.6)
 
+  packages/adapters/rules-srd: {}
+
   packages/core: {}
 
 packages:


### PR DESCRIPTION
## Summary
- add an SRD armor catalog and exports to the rules adapter
- derive AC, max HP, and default weapon profiles from character equipment and expose the data in the CLI
- add Vitest coverage for the new helpers and configure path resolution

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dee35728508327a5f9301d69f42d40