### PR TITLE
feat: add encounter conditions engine

### DIFF
--- a/packages/core/src/conditions.ts
+++ b/packages/core/src/conditions.ts
@@ -1,0 +1,81 @@
+export type Condition = 'prone' | 'restrained' | 'poisoned' | 'grappled';
+
+export interface ConditionSet {
+  [name: string]: true;
+}
+
+export function addCondition(set: ConditionSet | undefined, c: Condition): ConditionSet {
+  return { ...(set ?? {}), [c]: true };
+}
+
+export function removeCondition(set: ConditionSet | undefined, c: Condition): ConditionSet | undefined {
+  if (!set) return undefined;
+  const { [c]: _removed, ...rest } = set;
+  return Object.keys(rest).length ? rest : undefined;
+}
+
+export function hasCondition(set: ConditionSet | undefined, c: Condition): boolean {
+  return !!set?.[c];
+}
+
+export function combineAdvantage(
+  base: { advantage?: boolean; disadvantage?: boolean },
+  extra: { advantage?: boolean; disadvantage?: boolean },
+): { advantage?: boolean; disadvantage?: boolean } {
+  const advantage = !!base.advantage || !!extra.advantage;
+  const disadvantage = !!base.disadvantage || !!extra.disadvantage;
+
+  if (advantage && disadvantage) {
+    return {};
+  }
+
+  const result: { advantage?: boolean; disadvantage?: boolean } = {};
+  if (advantage) {
+    result.advantage = true;
+  }
+  if (disadvantage) {
+    result.disadvantage = true;
+  }
+  return result;
+}
+
+export function attackAdvFromConditions(
+  attacker: ConditionSet | undefined,
+  defender: ConditionSet | undefined,
+  mode: 'melee' | 'ranged',
+): { advantage?: boolean; disadvantage?: boolean } {
+  let advantage = false;
+  let disadvantage = false;
+
+  if (hasCondition(defender, 'prone')) {
+    if (mode === 'melee') {
+      advantage = true;
+    } else if (mode === 'ranged') {
+      disadvantage = true;
+    }
+  }
+
+  if (hasCondition(defender, 'restrained')) {
+    advantage = true;
+  }
+
+  if (hasCondition(attacker, 'restrained')) {
+    disadvantage = true;
+  }
+
+  if (hasCondition(attacker, 'poisoned')) {
+    disadvantage = true;
+  }
+
+  // Grappled does not affect attack rolls directly but is kept for completeness.
+
+  const result: { advantage?: boolean; disadvantage?: boolean } = {};
+  if (advantage) {
+    result.advantage = true;
+  }
+  if (disadvantage) {
+    result.disadvantage = true;
+  }
+
+  return result;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,14 @@ export type {
   ResolveAttackResult,
 } from './combat.js';
 export {
+  addCondition,
+  removeCondition,
+  hasCondition,
+  combineAdvantage,
+  attackAdvFromConditions,
+} from './conditions.js';
+export type { Condition, ConditionSet } from './conditions.js';
+export {
   chooseAttackAbility,
   resolveWeaponAttack,
 } from './weapons.js';
@@ -72,6 +80,8 @@ export {
   nextTurn,
   currentActor,
   actorAttack,
+  setCondition,
+  clearCondition,
   recordLoot,
   recordXP,
 } from './encounter.js';

--- a/packages/core/tests/conditions.test.ts
+++ b/packages/core/tests/conditions.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addCondition,
+  removeCondition,
+  hasCondition,
+  attackAdvFromConditions,
+  combineAdvantage,
+  type ConditionSet,
+} from '../src/conditions.js';
+import { addActor, actorAttack, createEncounter, type MonsterActor } from '../src/encounter.js';
+
+function createTestMonster(id: string, overrides: Partial<MonsterActor> = {}): MonsterActor {
+  return {
+    id,
+    name: id,
+    side: overrides.side ?? 'foe',
+    type: 'monster',
+    ac: overrides.ac ?? 12,
+    hp: overrides.hp ?? 10,
+    maxHp: overrides.maxHp ?? 10,
+    abilityMods: overrides.abilityMods ?? {},
+    proficiencyBonus: overrides.proficiencyBonus ?? 2,
+    attacks: overrides.attacks ?? [{ name: 'Strike', attackMod: 5, damageExpr: '1d6+3' }],
+    conditions: overrides.conditions,
+  };
+}
+
+describe('condition helpers', () => {
+  it('adds, checks, and removes conditions', () => {
+    let set: ConditionSet | undefined;
+    set = addCondition(set, 'prone');
+    expect(hasCondition(set, 'prone')).toBe(true);
+
+    set = addCondition(set, 'poisoned');
+    expect(sortedKeys(set)).toEqual(['poisoned', 'prone']);
+
+    set = removeCondition(set, 'prone');
+    expect(hasCondition(set, 'prone')).toBe(false);
+    expect(sortedKeys(set)).toEqual(['poisoned']);
+
+    set = removeCondition(set, 'poisoned');
+    expect(set).toBeUndefined();
+  });
+});
+
+describe('attackAdvFromConditions', () => {
+  it('handles prone defenders for melee attacks', () => {
+    const result = attackAdvFromConditions(undefined, { prone: true }, 'melee');
+    expect(result).toEqual({ advantage: true });
+  });
+
+  it('handles prone defenders for ranged attacks', () => {
+    const result = attackAdvFromConditions(undefined, { prone: true }, 'ranged');
+    expect(result).toEqual({ disadvantage: true });
+  });
+
+  it('grants advantage against restrained defenders', () => {
+    const result = attackAdvFromConditions(undefined, { restrained: true }, 'melee');
+    expect(result).toEqual({ advantage: true });
+  });
+
+  it('applies disadvantage to restrained attackers', () => {
+    const result = attackAdvFromConditions({ restrained: true }, undefined, 'melee');
+    expect(result).toEqual({ disadvantage: true });
+  });
+
+  it('applies disadvantage to poisoned attackers', () => {
+    const result = attackAdvFromConditions({ poisoned: true }, undefined, 'melee');
+    expect(result).toEqual({ disadvantage: true });
+  });
+
+  it('can produce both advantage and disadvantage', () => {
+    const result = attackAdvFromConditions({ restrained: true }, { restrained: true }, 'melee');
+    expect(result).toEqual({ advantage: true, disadvantage: true });
+  });
+});
+
+describe('combineAdvantage', () => {
+  it('cancels opposing advantage and disadvantage', () => {
+    const result = combineAdvantage({}, { advantage: true, disadvantage: true });
+    expect(result).toEqual({});
+  });
+
+  it('merges user-provided and condition flags', () => {
+    const result = combineAdvantage({ advantage: true }, { disadvantage: true });
+    expect(result).toEqual({});
+  });
+});
+
+describe('actorAttack integration with conditions', () => {
+  it('rolls with advantage when the defender is restrained', () => {
+    const attacker = createTestMonster('attacker');
+    const defender = createTestMonster('defender', { side: 'party', conditions: { restrained: true } });
+
+    let encounter = createEncounter('adv-condition');
+    encounter = addActor(encounter, attacker);
+    encounter = addActor(encounter, defender);
+
+    const result = actorAttack(encounter, attacker.id, defender.id, { seed: 'adv-seed' });
+    expect(result.attack.d20s).toEqual([20, 13]);
+    expect(result.attack.natural).toBe(20);
+    expect(result.attack.expression).toContain('adv');
+  });
+
+  it('rolls with disadvantage when the attacker is poisoned', () => {
+    const attacker = createTestMonster('attacker', { conditions: { poisoned: true } });
+    const defender = createTestMonster('defender', { side: 'party' });
+
+    let encounter = createEncounter('dis-condition');
+    encounter = addActor(encounter, attacker);
+    encounter = addActor(encounter, defender);
+
+    const result = actorAttack(encounter, attacker.id, defender.id, { seed: 'adv-seed' });
+    expect(result.attack.d20s).toEqual([20, 13]);
+    expect(result.attack.natural).toBe(13);
+    expect(result.attack.expression).toContain('dis');
+  });
+});
+
+function sortedKeys(set: ConditionSet | undefined): string[] {
+  return set ? Object.keys(set).sort() : [];
+}


### PR DESCRIPTION
## Summary
- add a reusable core conditions module that tracks advantage and disadvantage effects
- store actor conditions in encounters and fold them into attack resolution
- extend the CLI to manage conditions, display them during attacks, and show them in encounter listings
- cover the new helpers and integrations with dedicated tests

## Testing
- ⚠️ `pnpm test` *(not run: pnpm/node unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e02c9eaac083279bb4299c0e0684af