### PR TITLE
feat: support spell scaling and concentration tracking

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,6 +84,10 @@ export {
   clearCondition,
   recordLoot,
   recordXP,
+  startConcentration,
+  endConcentration,
+  getConcentration,
+  concentrationDCFromDamage,
 } from './encounter.js';
 export type {
   EncounterState,
@@ -94,8 +98,9 @@ export type {
   InitiativeEntry,
   WeaponProfile,
   Side,
+  ConcentrationEntry,
 } from './encounter.js';
 export { rollCoinsForCR, xpForCR, totalXP } from './loot.js';
 export type { CoinBundle, LootRoll } from './loot.js';
-export { castSpell, chooseCastingAbility, spellSaveDC } from './spells.js';
+export { castSpell, chooseCastingAbility, spellSaveDC, diceForCharacterLevel, diceForSlotLevel } from './spells.js';
 export type { CastOptions, CastResult, NormalizedSpell } from './spells.js';

--- a/packages/core/tests/concentration.test.ts
+++ b/packages/core/tests/concentration.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  concentrationDCFromDamage,
+  createEncounter,
+  endConcentration,
+  getConcentration,
+  startConcentration,
+} from '../src/index.js';
+
+describe('concentration helpers', () => {
+  test('concentrationDCFromDamage enforces minimum DC 10', () => {
+    expect(concentrationDCFromDamage(1)).toBe(10);
+    expect(concentrationDCFromDamage(15)).toBe(10);
+    expect(concentrationDCFromDamage(22)).toBe(11);
+    expect(concentrationDCFromDamage(31)).toBe(15);
+  });
+
+  test('startConcentration and endConcentration manage entries', () => {
+    const encounter = createEncounter();
+    const entry = { casterId: 'pc-1', spellName: 'Bless', targetId: 'ally-1' };
+
+    const withConcentration = startConcentration(encounter, entry);
+    expect(getConcentration(withConcentration, 'pc-1')).toEqual(entry);
+
+    const cleared = endConcentration(withConcentration, 'pc-1');
+    expect(getConcentration(cleared, 'pc-1')).toBeUndefined();
+  });
+
+  test('failed concentration checks can be resolved by clearing the entry', () => {
+    const entry = { casterId: 'pc-2', spellName: 'Hold Person' };
+    const encounter = startConcentration(createEncounter(), entry);
+
+    const dc = concentrationDCFromDamage(18);
+    expect(dc).toBe(10);
+
+    const rollTotal = 7; // simulated failed roll
+    expect(rollTotal).toBeLessThan(dc);
+
+    const afterFailure = endConcentration(encounter, entry.casterId);
+    expect(getConcentration(afterFailure, entry.casterId)).toBeUndefined();
+  });
+});

--- a/packages/core/tests/spells.test.ts
+++ b/packages/core/tests/spells.test.ts
@@ -2,7 +2,14 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
 
-import { castSpell, chooseCastingAbility, spellSaveDC, type NormalizedSpell } from '../src/spells.js';
+import {
+  castSpell,
+  chooseCastingAbility,
+  diceForCharacterLevel,
+  diceForSlotLevel,
+  spellSaveDC,
+  type NormalizedSpell,
+} from '../src/spells.js';
 import type { Character } from '../src/character.js';
 import { normalizeSpell } from '../../adapters/dnd5e-api/src/spells.js';
 
@@ -21,6 +28,48 @@ describe('spells', () => {
     expect(spell.dcAbility).toBe('WIS');
     expect(spell.info?.range).toBe('60 feet');
     expect(spell.info?.casting_time).toBe('1 action');
+    expect(spell.damageAtCharacterLevel?.[1]).toBe('1d8');
+    expect(spell.damageAtCharacterLevel?.[5]).toBe('2d8');
+    expect(spell.concentration).toBe(false);
+  });
+
+  test('diceForCharacterLevel selects highest threshold without exceeding level', () => {
+    const spell: NormalizedSpell = {
+      name: 'Test Cantrip',
+      level: 0,
+      damageDice: '1d8',
+      damageAtCharacterLevel: {
+        1: '1d8',
+        5: '2d8',
+        11: '3d8',
+        17: '4d8',
+      },
+    };
+
+    expect(diceForCharacterLevel(spell, 1)).toBe('1d8');
+    expect(diceForCharacterLevel(spell, 4)).toBe('1d8');
+    expect(diceForCharacterLevel(spell, 5)).toBe('2d8');
+    expect(diceForCharacterLevel(spell, 13)).toBe('3d8');
+    expect(diceForCharacterLevel(spell, 20)).toBe('4d8');
+  });
+
+  test('diceForSlotLevel prefers exact slot match', () => {
+    const spell: NormalizedSpell = {
+      name: 'Scaled Spell',
+      level: 1,
+      damageDice: '3d6',
+      damageAtSlotLevel: {
+        1: '3d6',
+        2: '4d6',
+        3: '5d6',
+      },
+    };
+
+    expect(diceForSlotLevel(spell, 1)).toBe('3d6');
+    expect(diceForSlotLevel(spell, 2)).toBe('4d6');
+    expect(diceForSlotLevel(spell, 3)).toBe('5d6');
+    expect(diceForSlotLevel(spell, 4)).toBe('3d6');
+    expect(diceForSlotLevel(spell, undefined)).toBe('3d6');
   });
 
   test('spellSaveDC computes 8 + PB + ability modifier', () => {
@@ -89,6 +138,73 @@ describe('spells', () => {
     expect(result.save?.dc).toBe(14);
     expect(result.damage?.expression).toBe('2d6+3');
     expect(result.damage?.final).toBeGreaterThanOrEqual(5);
+  });
+
+  test('castSpell scales cantrip damage by character level', () => {
+    const spell: NormalizedSpell = {
+      name: 'Radiant Spark',
+      level: 0,
+      save: { ability: 'DEX', onSuccess: 'half' },
+      damageDice: '1d8',
+      damageAtCharacterLevel: {
+        1: '1d8',
+        5: '2d8',
+      },
+    };
+
+    const level1Caster: Character = {
+      name: 'Novice',
+      level: 1,
+      abilities: {
+        STR: 8,
+        DEX: 10,
+        CON: 12,
+        INT: 10,
+        WIS: 16,
+        CHA: 10,
+      },
+    };
+
+    const level5Caster: Character = { ...level1Caster, level: 5 };
+
+    const result1 = castSpell({ caster: level1Caster, spell, castingAbility: 'WIS', seed: 'cantrip-l1' });
+    const result5 = castSpell({ caster: level5Caster, spell, castingAbility: 'WIS', seed: 'cantrip-l5' });
+
+    expect(result1.damage?.expression).toBe('1d8+3');
+    expect(result5.damage?.expression).toBe('2d8+3');
+  });
+
+  test('castSpell scales slot damage when provided', () => {
+    const spell: NormalizedSpell = {
+      name: 'Guiding Ray',
+      level: 1,
+      save: { ability: 'DEX', onSuccess: 'half' },
+      damageDice: '4d6',
+      damageAtSlotLevel: {
+        1: '4d6',
+        2: '5d6',
+        3: '6d6',
+      },
+    };
+
+    const caster: Character = {
+      name: 'Cleric',
+      level: 5,
+      abilities: {
+        STR: 10,
+        DEX: 10,
+        CON: 12,
+        INT: 10,
+        WIS: 16,
+        CHA: 10,
+      },
+    };
+
+    const result1 = castSpell({ caster, spell, castingAbility: 'WIS', slotLevel: 1, seed: 'slot-1' });
+    const result3 = castSpell({ caster, spell, castingAbility: 'WIS', slotLevel: 3, seed: 'slot-3' });
+
+    expect(result1.damage?.expression).toBe('4d6+3');
+    expect(result3.damage?.expression).toBe('6d6+3');
   });
 
   test('castSpell returns attack result including hit and damage', () => {


### PR DESCRIPTION
## Summary
- expose spell scaling fields from the adapter and scale damage by caster level or slot when casting
- add encounter concentration state helpers and auto-start concentration for PC spell casts
- expand the CLI with concentration management commands and update tests for scaling and concentration

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e2a013e25c8327b12156b4b0265f5d