### PR TITLE
feat: add spell slot tracking and rest support

### DIFF
--- a/packages/core/src/encounter.ts
+++ b/packages/core/src/encounter.ts
@@ -195,6 +195,13 @@ export function createEncounter(seed?: string): EncounterState {
   };
 }
 
+export function clearAllConcentration(state: EncounterState): EncounterState {
+  if (!state.concentration || Object.keys(state.concentration).length === 0) {
+    return state;
+  }
+  return { ...state, concentration: {} };
+}
+
 export function addActor(state: EncounterState, actor: Actor): EncounterState {
   const actors = { ...state.actors, [actor.id]: actor };
   const defeated = cloneDefeated(state.defeated);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,6 +63,11 @@ export {
   passivePerception,
   setCharacterWeaponLookup,
   setCharacterArmorData,
+  ensureSlots,
+  canSpendSlot,
+  spendSlot,
+  restoreAllSlots,
+  setSlots,
 } from './character.js';
 export type {
   Character,
@@ -70,6 +75,7 @@ export type {
   CharacterProficiencies,
   Equipped,
   SkillName,
+  SpellSlots,
 } from './character.js';
 export { SKILL_ABILITY } from './skills.js';
 export {
@@ -83,6 +89,7 @@ export {
   encounterAbilityCheck,
   setCondition,
   clearCondition,
+  clearAllConcentration,
   recordLoot,
   recordXP,
   startConcentration,

--- a/packages/core/tests/slots.test.ts
+++ b/packages/core/tests/slots.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ensureSlots,
+  setSlots,
+  spendSlot,
+  castSpell,
+  type Character,
+} from '../src/index.js';
+import type { NormalizedSpell } from '@grimengine/dnd5e-api/spells.js';
+
+function createCharacter(): Character {
+  return {
+    name: 'Tester',
+    level: 5,
+    abilities: {
+      STR: 10,
+      DEX: 10,
+      CON: 10,
+      INT: 10,
+      WIS: 10,
+      CHA: 10,
+    },
+  };
+}
+
+describe('ensureSlots', () => {
+  it('initializes zeroed slot tables when absent', () => {
+    const character = createCharacter();
+    const slots = ensureSlots(character);
+
+    for (let level = 1; level <= 9; level += 1) {
+      expect(slots.max[level]).toBe(0);
+      expect(slots.remaining[level]).toBe(0);
+    }
+  });
+
+  it('mirrors max values into remaining on first setup', () => {
+    const character = createCharacter();
+    character.slots = { max: { 1: 3 } as Record<number, number> } as any;
+
+    const slots = ensureSlots(character);
+    expect(slots.max[1]).toBe(3);
+    expect(slots.remaining[1]).toBe(3);
+  });
+});
+
+describe('setSlots', () => {
+  it('updates max slots and clamps remaining when necessary', () => {
+    const character = createCharacter();
+
+    setSlots(character, { 1: 4, 2: 2 });
+    let slots = ensureSlots(character);
+    expect(slots.max[1]).toBe(4);
+    expect(slots.remaining[1]).toBe(4);
+    expect(slots.max[2]).toBe(2);
+    expect(slots.remaining[2]).toBe(2);
+
+    slots.remaining[1] = 3;
+    setSlots(character, { 1: 2, 3: 1 });
+    slots = ensureSlots(character);
+    expect(slots.max[1]).toBe(2);
+    expect(slots.remaining[1]).toBe(2);
+    expect(slots.max[3]).toBe(1);
+    expect(slots.remaining[3]).toBe(1);
+
+    slots.remaining[1] = 2;
+    setSlots(character, { 1: 1 });
+    slots = ensureSlots(character);
+    expect(slots.max[1]).toBe(1);
+    expect(slots.remaining[1]).toBe(1);
+  });
+});
+
+describe('spendSlot', () => {
+  it('spends available slots and reports exhaustion', () => {
+    const character = createCharacter();
+    setSlots(character, { 1: 1 });
+
+    expect(spendSlot(character, 1)).toBe(true);
+    let slots = ensureSlots(character);
+    expect(slots.remaining[1]).toBe(0);
+
+    expect(spendSlot(character, 1)).toBe(false);
+    slots = ensureSlots(character);
+    expect(slots.remaining[1]).toBe(0);
+  });
+});
+
+describe('castSpell slot enforcement', () => {
+  it('returns a note when no slot is available for the requested level', () => {
+    const character = createCharacter();
+    setSlots(character, { 1: 1 });
+    const slots = ensureSlots(character);
+    slots.remaining[1] = 0;
+
+    const spell: NormalizedSpell = {
+      name: 'Test Spell',
+      level: 1,
+      damageDice: '1d6',
+    };
+
+    const result = castSpell({ caster: character, spell, slotLevel: 1 });
+
+    expect(result.kind).toBe('none');
+    expect(result.notes).toBeDefined();
+    expect(result.notes).toContain('No slot available at level 1.');
+  });
+});

--- a/packages/core/tests/spells.test.ts
+++ b/packages/core/tests/spells.test.ts
@@ -10,7 +10,7 @@ import {
   spellSaveDC,
   type NormalizedSpell,
 } from '../src/spells.js';
-import type { Character } from '../src/character.js';
+import { ensureSlots, setSlots, type Character } from '../src/character.js';
 import { normalizeSpell } from '../../adapters/dnd5e-api/src/spells.js';
 
 const sacredFlameFixturePath = fileURLToPath(new URL('./fixtures/sacred-flame.api.json', import.meta.url));
@@ -124,6 +124,8 @@ describe('spells', () => {
       },
     };
 
+    setSlots(caster, { 1: 2 });
+
     const spell: NormalizedSpell = {
       name: 'Radiant Burst',
       level: 1,
@@ -199,6 +201,9 @@ describe('spells', () => {
         CHA: 10,
       },
     };
+
+    setSlots(caster, { 1: 2, 2: 2, 3: 2 });
+    ensureSlots(caster);
 
     const result1 = castSpell({ caster, spell, castingAbility: 'WIS', slotLevel: 1, seed: 'slot-1' });
     const result3 = castSpell({ caster, spell, castingAbility: 'WIS', slotLevel: 3, seed: 'slot-3' });


### PR DESCRIPTION
## Summary
- add spell slot data and helper utilities to the core character model with slot spending enforcement for spells
- expose concentration clearing and slot management helpers while adding CLI commands for viewing, setting, and restoring slots
- guard leveled spell casting with slot availability checks, persist slot usage, and cover the behavior with new unit tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e3c47bb6c083278dee662b946cb3fa