### PR TITLE
feat(core+cli): add bless/hunters-mark helpers and CLI commands

### DIFF
--- a/packages/core/src/concentrationHelpers.ts
+++ b/packages/core/src/concentrationHelpers.ts
@@ -1,0 +1,393 @@
+import {
+  addActorTagDetailed,
+  getConcentration,
+  removeActorTag,
+  removeConcentration,
+  startConcentration,
+  type Actor,
+  type ActorTag,
+  type ConcentrationEntry,
+  type ConcentrationRemovalResult,
+  type ConcentrationTagLink,
+  type EncounterState,
+} from './encounter.js';
+
+export interface DurationSpec {
+  rounds?: number;
+  seconds?: number;
+  encounterClock?: boolean;
+  label: string;
+}
+
+interface ExpirationDetails {
+  expiresAtRound?: number;
+  expiresAtTimestamp?: number;
+  encounterClock?: boolean;
+}
+
+function computeExpiration(state: EncounterState, duration: DurationSpec, now: number): ExpirationDetails {
+  const expiresAtRound =
+    typeof duration.rounds === 'number' && duration.rounds > 0
+      ? state.round + Math.max(0, duration.rounds - 1)
+      : undefined;
+  const expiresAtTimestamp =
+    typeof duration.seconds === 'number' && duration.seconds > 0 ? now + duration.seconds * 1000 : undefined;
+  const encounterClock = duration.encounterClock ?? Boolean(duration.rounds && duration.rounds > 0);
+  return { expiresAtRound, expiresAtTimestamp, encounterClock };
+}
+
+export interface AppliedTagSummary {
+  actorId: string;
+  actorName: string;
+  tag: ActorTag;
+}
+
+export interface ConcentrationBreakSummary {
+  result: ConcentrationRemovalResult;
+  reason?: string;
+}
+
+export interface ConcentrationLifecycleResult {
+  state: EncounterState;
+  concentration: ConcentrationEntry;
+  caster: Actor;
+  break?: ConcentrationBreakSummary;
+}
+
+export interface BlessCastOptions {
+  casterId: string;
+  targetIds: string[];
+  slotLevel?: number;
+  duration?: DurationSpec;
+  note?: string;
+  breakReason?: string;
+}
+
+export interface BlessCastResult extends ConcentrationLifecycleResult {
+  targets: Actor[];
+  effectTags: AppliedTagSummary[];
+  concentrationTag?: AppliedTagSummary;
+}
+
+export interface HuntersMarkCastOptions {
+  casterId: string;
+  targetId: string;
+  duration?: DurationSpec;
+  note?: string;
+  breakReason?: string;
+}
+
+export interface HuntersMarkCastResult extends ConcentrationLifecycleResult {
+  target: Actor;
+  effectTags: AppliedTagSummary[];
+  concentrationTag?: AppliedTagSummary;
+}
+
+export interface HuntersMarkTransferOptions {
+  casterId: string;
+  targetId: string;
+  note?: string;
+}
+
+export interface HuntersMarkTransferResult extends ConcentrationLifecycleResult {
+  target: Actor;
+  previousTarget?: Actor;
+  removedTags: AppliedTagSummary[];
+  effectTags: AppliedTagSummary[];
+  concentrationTag?: AppliedTagSummary;
+}
+
+class ConcentrationHelperBase {
+  protected state: EncounterState;
+  protected readonly now: number;
+
+  constructor(state: EncounterState, now = Date.now()) {
+    this.state = state;
+    this.now = now;
+  }
+
+  protected requireActor(actorId: string): Actor {
+    const actor = this.state.actors[actorId];
+    if (!actor) {
+      throw new Error(`Unknown actor: ${actorId}`);
+    }
+    return actor;
+  }
+
+  protected prepareBreak(casterId: string, reason?: string): ConcentrationBreakSummary | undefined {
+    const existing = getConcentration(this.state, casterId);
+    if (!existing) {
+      return undefined;
+    }
+    const result = removeConcentration(this.state, casterId);
+    this.state = result.state;
+    return { result, reason };
+  }
+
+  protected pushLink(links: ConcentrationTagLink[] | undefined, link: ConcentrationTagLink): ConcentrationTagLink[] {
+    const next = links ? [...links, link] : [link];
+    return next;
+  }
+
+  protected applyTag(actor: Actor, tag: Omit<ActorTag, 'id' | 'addedAtRound'>): AppliedTagSummary | undefined {
+    const { state: nextState, tag: created } = addActorTagDetailed(this.state, actor.id, tag);
+    this.state = nextState;
+    if (!created) {
+      return undefined;
+    }
+    return { actorId: actor.id, actorName: actor.name, tag: created };
+  }
+
+  protected baseLifecycleResult(entry: ConcentrationEntry, caster: Actor, breakSummary?: ConcentrationBreakSummary) {
+    return { state: this.state, concentration: entry, caster, break: breakSummary } satisfies ConcentrationLifecycleResult;
+  }
+}
+
+export class BlessHelper extends ConcentrationHelperBase {
+  static defaultDuration(): DurationSpec {
+    return { rounds: 10, encounterClock: true, label: '10 rounds' };
+  }
+
+  cast(options: BlessCastOptions): BlessCastResult {
+    const caster = this.requireActor(options.casterId);
+    const duration = options.duration ?? BlessHelper.defaultDuration();
+    const expiration = computeExpiration(this.state, duration, this.now);
+
+    const level = options.slotLevel ?? 1;
+    if (!Number.isFinite(level) || level < 1) {
+      throw new Error('Bless slot level must be at least 1.');
+    }
+
+    const allowedTargets = 3 + Math.max(0, Math.floor(level) - 1);
+    const uniqueTargets = Array.from(new Set(options.targetIds.map((id) => id.trim()).filter((id) => id.length > 0)));
+    if (uniqueTargets.length === 0) {
+      throw new Error('Bless requires at least one target.');
+    }
+    if (uniqueTargets.length > allowedTargets) {
+      throw new Error(`Too many targets (max ${allowedTargets} at level ${level}).`);
+    }
+
+    const targets = uniqueTargets.map((id) => this.requireActor(id));
+    const breakSummary = this.prepareBreak(caster.id, options.breakReason);
+
+    let links: ConcentrationTagLink[] | undefined;
+    const effectTags: AppliedTagSummary[] = [];
+
+    targets.forEach((target) => {
+      const applied = this.applyTag(target, {
+        text: 'effect:bless',
+        expiresAtRound: expiration.expiresAtRound,
+        expiresAtTimestamp: expiration.expiresAtTimestamp,
+        encounterClock: expiration.encounterClock,
+        note: '+1d4 to attack rolls and saving throws',
+        source: caster.name,
+      });
+      if (applied) {
+        effectTags.push(applied);
+        links = this.pushLink(links, { actorId: target.id, tagId: applied.tag.id });
+      }
+    });
+
+    const concentrationTag = this.applyTag(caster, {
+      text: 'concentration:bless',
+      expiresAtRound: expiration.expiresAtRound,
+      expiresAtTimestamp: expiration.expiresAtTimestamp,
+      encounterClock: expiration.encounterClock,
+      note: `Maintaining Bless (${duration.label})`,
+      source: caster.name,
+    });
+    if (concentrationTag) {
+      links = this.pushLink(links, { actorId: caster.id, tagId: concentrationTag.tag.id });
+    }
+
+    const entry: ConcentrationEntry = {
+      casterId: caster.id,
+      spellId: 'bless',
+      spellName: 'Bless',
+      targetId: targets[0]?.id,
+      targetIds: targets.map((target) => target.id),
+      durationLabel: duration.label,
+      note: options.note,
+      linkedTags: links,
+      expiresAtRound: expiration.expiresAtRound,
+      expiresAtTimestamp: expiration.expiresAtTimestamp,
+      encounterClock: expiration.encounterClock,
+    };
+
+    this.state = startConcentration(this.state, entry);
+
+    return {
+      ...this.baseLifecycleResult(entry, caster, breakSummary),
+      targets,
+      effectTags,
+      concentrationTag,
+    };
+  }
+}
+
+export class HuntersMarkHelper extends ConcentrationHelperBase {
+  static defaultDuration(): DurationSpec {
+    return { seconds: 3600, encounterClock: false, label: '1 hour' };
+  }
+
+  cast(options: HuntersMarkCastOptions): HuntersMarkCastResult {
+    const caster = this.requireActor(options.casterId);
+    const target = this.requireActor(options.targetId);
+    const duration = options.duration ?? HuntersMarkHelper.defaultDuration();
+    const expiration = computeExpiration(this.state, duration, this.now);
+
+    const breakSummary = this.prepareBreak(caster.id, options.breakReason);
+
+    let links: ConcentrationTagLink[] | undefined;
+    const effectTags: AppliedTagSummary[] = [];
+
+    const damageTag = this.applyTag(target, {
+      text: 'effect:hunters-mark',
+      expiresAtRound: expiration.expiresAtRound,
+      expiresAtTimestamp: expiration.expiresAtTimestamp,
+      encounterClock: expiration.encounterClock,
+      note: '+1d6 weapon damage from caster',
+      source: caster.name,
+    });
+    if (damageTag) {
+      effectTags.push(damageTag);
+      links = this.pushLink(links, { actorId: target.id, tagId: damageTag.tag.id });
+    }
+
+    const markerTag = this.applyTag(target, {
+      text: `marked-by:${caster.id}`,
+      expiresAtRound: expiration.expiresAtRound,
+      expiresAtTimestamp: expiration.expiresAtTimestamp,
+      encounterClock: expiration.encounterClock,
+      note: "Hunter's Mark",
+      source: caster.name,
+    });
+    if (markerTag) {
+      effectTags.push(markerTag);
+      links = this.pushLink(links, { actorId: target.id, tagId: markerTag.tag.id });
+    }
+
+    const concentrationTag = this.applyTag(caster, {
+      text: 'concentration:hunters-mark',
+      expiresAtRound: expiration.expiresAtRound,
+      expiresAtTimestamp: expiration.expiresAtTimestamp,
+      encounterClock: expiration.encounterClock,
+      note: `Maintaining Hunter's Mark (${duration.label})`,
+      source: caster.name,
+    });
+    if (concentrationTag) {
+      links = this.pushLink(links, { actorId: caster.id, tagId: concentrationTag.tag.id });
+    }
+
+    const entry: ConcentrationEntry = {
+      casterId: caster.id,
+      spellId: 'hunters-mark',
+      spellName: "Hunter's Mark",
+      targetId: target.id,
+      targetIds: [target.id],
+      durationLabel: duration.label,
+      note: options.note,
+      linkedTags: links,
+      expiresAtRound: expiration.expiresAtRound,
+      expiresAtTimestamp: expiration.expiresAtTimestamp,
+      encounterClock: expiration.encounterClock,
+    };
+
+    this.state = startConcentration(this.state, entry);
+
+    return {
+      ...this.baseLifecycleResult(entry, caster, breakSummary),
+      target,
+      effectTags,
+      concentrationTag,
+    };
+  }
+
+  transfer(options: HuntersMarkTransferOptions): HuntersMarkTransferResult {
+    const caster = this.requireActor(options.casterId);
+    const target = this.requireActor(options.targetId);
+    const entry = getConcentration(this.state, caster.id);
+    if (!entry || entry.spellId !== 'hunters-mark') {
+      throw new Error('No active Hunter\'s Mark concentration to transfer.');
+    }
+
+    const previousTargetId = entry.targetId;
+    const previousTarget = previousTargetId ? this.state.actors[previousTargetId] : undefined;
+
+    const remainingLinks: ConcentrationTagLink[] = [];
+    const removedSummaries: AppliedTagSummary[] = [];
+
+    (entry.linkedTags ?? []).forEach((link) => {
+      if (link.actorId === caster.id) {
+        remainingLinks.push({ ...link });
+        return;
+      }
+      if (previousTargetId && link.actorId === previousTargetId) {
+        const actor = this.state.actors[link.actorId];
+        const tag = actor?.tags?.find((item) => item.id === link.tagId);
+        if (actor && tag) {
+          const summary: AppliedTagSummary = { actorId: actor.id, actorName: actor.name, tag };
+          removedSummaries.push(summary);
+          this.state = removeActorTag(this.state, actor.id, tag.id);
+        }
+        return;
+      }
+      remainingLinks.push({ ...link });
+    });
+
+    const expiration: ExpirationDetails = {
+      expiresAtRound: entry.expiresAtRound,
+      expiresAtTimestamp: entry.expiresAtTimestamp,
+      encounterClock: entry.encounterClock,
+    };
+
+    const effectTags: AppliedTagSummary[] = [];
+
+    const damageTag = this.applyTag(target, {
+      text: 'effect:hunters-mark',
+      expiresAtRound: expiration.expiresAtRound,
+      expiresAtTimestamp: expiration.expiresAtTimestamp,
+      encounterClock: expiration.encounterClock,
+      note: '+1d6 weapon damage from caster',
+      source: caster.name,
+    });
+    if (damageTag) {
+      effectTags.push(damageTag);
+      remainingLinks.push({ actorId: target.id, tagId: damageTag.tag.id });
+    }
+
+    const markerTag = this.applyTag(target, {
+      text: `marked-by:${caster.id}`,
+      expiresAtRound: expiration.expiresAtRound,
+      expiresAtTimestamp: expiration.expiresAtTimestamp,
+      encounterClock: expiration.encounterClock,
+      note: "Hunter's Mark",
+      source: caster.name,
+    });
+    if (markerTag) {
+      effectTags.push(markerTag);
+      remainingLinks.push({ actorId: target.id, tagId: markerTag.tag.id });
+    }
+
+    const updatedEntry: ConcentrationEntry = {
+      ...entry,
+      targetId: target.id,
+      targetIds: [target.id],
+      linkedTags: remainingLinks,
+      note: options.note ?? entry.note,
+    };
+
+    const concentration = { ...(this.state.concentration ?? {}) };
+    concentration[caster.id] = updatedEntry;
+    this.state = { ...this.state, concentration };
+
+    return {
+      ...this.baseLifecycleResult(updatedEntry, caster),
+      target,
+      previousTarget,
+      removedTags: removedSummaries,
+      effectTags,
+      concentrationTag: undefined,
+    };
+  }
+}

--- a/packages/core/src/encounter.ts
+++ b/packages/core/src/encounter.ts
@@ -9,7 +9,7 @@ import {
 } from './conditions.js';
 import { abilityCheck } from './checks.js';
 import type { ResolveAttackResult } from './combat.js';
-import { resolveAttack } from './combat.js';
+import { resolveAttack, damageRoll } from './combat.js';
 import { roll } from './dice.js';
 import type { CoinBundle } from './loot.js';
 
@@ -20,6 +20,8 @@ export interface ActorTag {
   text: string;
   addedAtRound: number;
   expiresAtRound?: number;
+  expiresAtTimestamp?: number;
+  encounterClock?: boolean;
   note?: string;
   source?: string;
 }
@@ -62,10 +64,23 @@ export interface InitiativeEntry {
   total: number;
 }
 
+export interface ConcentrationTagLink {
+  actorId: string;
+  tagId: string;
+}
+
 export interface ConcentrationEntry {
   casterId: string;
+  spellId?: string;
   spellName: string;
   targetId?: string;
+  targetIds?: string[];
+  expiresAtRound?: number;
+  expiresAtTimestamp?: number;
+  encounterClock?: boolean;
+  durationLabel?: string;
+  note?: string;
+  linkedTags?: ConcentrationTagLink[];
 }
 
 export interface EncounterState {
@@ -214,14 +229,19 @@ function nextTagIdentifier(tags: ActorTag[] | undefined): string {
   return `t${index}`;
 }
 
-export function addActorTag(
+export interface AddActorTagResult {
+  state: EncounterState;
+  tag?: ActorTag;
+}
+
+export function addActorTagDetailed(
   state: EncounterState,
   actorId: string,
   tag: Omit<ActorTag, 'id' | 'addedAtRound'>,
-): EncounterState {
+): AddActorTagResult {
   const actor = state.actors[actorId];
   if (!actor) {
-    return state;
+    return { state };
   }
 
   const currentTags = actor.tags ? [...actor.tags] : [];
@@ -231,7 +251,16 @@ export function addActorTag(
     addedAtRound: state.round,
   };
   const updatedActor: Actor = { ...actor, tags: [...currentTags, newTag] };
-  return { ...state, actors: { ...state.actors, [actorId]: updatedActor } };
+  const nextState = { ...state, actors: { ...state.actors, [actorId]: updatedActor } };
+  return { state: nextState, tag: newTag };
+}
+
+export function addActorTag(
+  state: EncounterState,
+  actorId: string,
+  tag: Omit<ActorTag, 'id' | 'addedAtRound'>,
+): EncounterState {
+  return addActorTagDetailed(state, actorId, tag).state;
 }
 
 export function removeActorTag(state: EncounterState, actorId: string, tagId: string): EncounterState {
@@ -290,7 +319,11 @@ export function clearAllConcentration(state: EncounterState): EncounterState {
   if (!state.concentration || Object.keys(state.concentration).length === 0) {
     return state;
   }
-  return { ...state, concentration: {} };
+  let nextState: EncounterState = state;
+  Object.keys(state.concentration).forEach((casterId) => {
+    nextState = removeConcentration(nextState, casterId).state;
+  });
+  return { ...nextState, concentration: {} };
 }
 
 export function addActor(state: EncounterState, actor: Actor): EncounterState {
@@ -531,9 +564,36 @@ export function actorAttack(
 
   let nextState = state;
   let defenderHp = defender.hp;
-  const damage = attackResult.damage;
+  let damage = attackResult.damage ? { ...attackResult.damage } : undefined;
 
   if (attackResult.attack.isCrit || attackResult.attack.hit === true) {
+    const hmEntry = state.concentration?.[attackerId];
+    if (hmEntry?.spellId === 'hunters-mark' && hmEntry.targetId === defenderId) {
+      const hmSeed = damageSeed ? `${damageSeed}:hunters-mark` : undefined;
+      const hmRoll = damageRoll({ expression: '1d6', seed: hmSeed, crit: attackResult.attack.isCrit });
+      if (damage) {
+        const critRolls = attackResult.attack.isCrit
+          ? [...(damage.critRolls ?? []), ...(hmRoll.critRolls ?? [])]
+          : damage.critRolls;
+        damage = {
+          ...damage,
+          rolls: [...damage.rolls, ...hmRoll.rolls],
+          critRolls,
+          baseTotal: damage.baseTotal + hmRoll.baseTotal,
+          finalTotal: damage.finalTotal + hmRoll.finalTotal,
+          expression: `${damage.expression} + Hunter's Mark 1d6`,
+        };
+      } else {
+        damage = {
+          rolls: [...hmRoll.rolls],
+          critRolls: hmRoll.critRolls ? [...hmRoll.critRolls] : undefined,
+          baseTotal: hmRoll.baseTotal,
+          finalTotal: hmRoll.finalTotal,
+          expression: "Hunter's Mark 1d6",
+        };
+      }
+    }
+
     const damageTotal = damage?.finalTotal ?? 0;
     nextState = applyDamage(nextState, defenderId, damageTotal);
     defenderHp = nextState.actors[defenderId]?.hp ?? 0;
@@ -570,20 +630,65 @@ export function recordXP(state: EncounterState, entry: { crs: string[]; total: n
 
 export function startConcentration(state: EncounterState, entry: ConcentrationEntry): EncounterState {
   const existing = state.concentration ?? {};
+  const clone = {
+    ...entry,
+    linkedTags: entry.linkedTags?.map((link) => ({ ...link })),
+    targetIds: entry.targetIds ? [...entry.targetIds] : entry.targetId ? [entry.targetId] : undefined,
+  } satisfies ConcentrationEntry;
   const concentration: Record<string, ConcentrationEntry> = {
     ...existing,
-    [entry.casterId]: { ...entry },
+    [entry.casterId]: clone,
   };
   return { ...state, concentration };
 }
 
-export function endConcentration(state: EncounterState, casterId: string): EncounterState {
-  if (!state.concentration || !state.concentration[casterId]) {
-    return state.concentration ? state : { ...state, concentration: {} };
+export interface ConcentrationRemovalResult {
+  state: EncounterState;
+  entry?: ConcentrationEntry;
+  removedTags: { actorId: string; tagId: string; tag?: ActorTag }[];
+}
+
+export function removeConcentration(state: EncounterState, casterId: string): ConcentrationRemovalResult {
+  const existingEntry = state.concentration?.[casterId];
+  if (!existingEntry) {
+    if (!state.concentration) {
+      return { state: { ...state, concentration: {} }, removedTags: [] };
+    }
+    if (!(casterId in state.concentration)) {
+      return { state, removedTags: [] };
+    }
   }
-  const concentration = { ...state.concentration };
+
+  let nextState = state;
+  const removedTags: { actorId: string; tagId: string; tag?: ActorTag }[] = [];
+  if (existingEntry?.linkedTags) {
+    existingEntry.linkedTags.forEach((link) => {
+      const actor = nextState.actors[link.actorId];
+      if (!actor || !actor.tags) {
+        return;
+      }
+      const tag = actor.tags.find((item) => item.id === link.tagId);
+      if (!tag) {
+        return;
+      }
+      removedTags.push({ actorId: link.actorId, tagId: link.tagId, tag });
+      nextState = removeActorTag(nextState, link.actorId, link.tagId);
+    });
+  }
+
+  if (!nextState.concentration) {
+    nextState = { ...nextState, concentration: {} };
+  }
+
+  const concentration = { ...(nextState.concentration ?? {}) };
   delete concentration[casterId];
-  return { ...state, concentration };
+  nextState = { ...nextState, concentration };
+
+  return { state: nextState, entry: existingEntry, removedTags };
+}
+
+export function endConcentration(state: EncounterState, casterId: string): EncounterState {
+  return removeConcentration(state, casterId).state;
 }
 
 export function getConcentration(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -90,6 +90,7 @@ export {
   setCondition,
   clearCondition,
   addActorTag,
+  addActorTagDetailed,
   removeActorTag,
   clearActorTags,
   expireActorTags,
@@ -99,6 +100,7 @@ export {
   startConcentration,
   endConcentration,
   getConcentration,
+  removeConcentration,
   concentrationDCFromDamage,
 } from './encounter.js';
 export type {
@@ -106,14 +108,31 @@ export type {
   Actor,
   ActorBase,
   ActorTag,
+  AddActorTagResult,
   MonsterActor,
   PlayerActor,
   InitiativeEntry,
   WeaponProfile,
   Side,
   ConcentrationEntry,
+  ConcentrationTagLink,
+  ConcentrationRemovalResult,
   EncounterCheckInput,
 } from './encounter.js';
+export {
+  BlessHelper,
+  HuntersMarkHelper,
+  type DurationSpec,
+  type AppliedTagSummary,
+  type BlessCastOptions,
+  type BlessCastResult,
+  type HuntersMarkCastOptions,
+  type HuntersMarkCastResult,
+  type HuntersMarkTransferOptions,
+  type HuntersMarkTransferResult,
+  type ConcentrationBreakSummary,
+  type ConcentrationLifecycleResult,
+} from './concentrationHelpers.js';
 export { rollCoinsForCR, xpForCR, totalXP } from './loot.js';
 export type { CoinBundle, LootRoll } from './loot.js';
 export { castSpell, chooseCastingAbility, spellSaveDC, diceForCharacterLevel, diceForSlotLevel } from './spells.js';

--- a/packages/core/tests/concentration-helpers.test.ts
+++ b/packages/core/tests/concentration-helpers.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addActor,
+  createEncounter,
+  getConcentration,
+  removeConcentration,
+  type EncounterState,
+  type PlayerActor,
+} from '../src/encounter.js';
+import {
+  BlessHelper,
+  HuntersMarkHelper,
+  type DurationSpec,
+} from '../src/concentrationHelpers.js';
+
+function createPc(id: string, name: string): PlayerActor {
+  return {
+    id,
+    name,
+    side: 'party',
+    type: 'pc',
+    ac: 15,
+    hp: 20,
+    maxHp: 20,
+    abilityMods: { STR: 3, DEX: 2 },
+    proficiencyBonus: 3,
+    defaultWeapon: { name: 'Longsword', attackMod: 6, damageExpr: '1d8+4' },
+  };
+}
+
+function setupEncounter(): EncounterState {
+  let encounter = createEncounter('helper-test');
+  encounter = addActor(encounter, createPc('pc-1', 'Bruni'));
+  encounter = addActor(encounter, createPc('pc-2', 'Aella'));
+  encounter = addActor(encounter, createPc('pc-3', 'Thorin'));
+  encounter = addActor(encounter, createPc('pc-4', 'Kara'));
+  encounter = addActor(encounter, {
+    id: 'foe-1',
+    name: 'Orc1',
+    side: 'foe',
+    type: 'monster',
+    ac: 13,
+    hp: 15,
+    maxHp: 15,
+    abilityMods: { STR: 3, DEX: 1 },
+    attacks: [{ name: 'Greataxe', attackMod: 5, damageExpr: '1d12+3' }],
+  });
+  encounter = addActor(encounter, {
+    id: 'foe-2',
+    name: 'Orc2',
+    side: 'foe',
+    type: 'monster',
+    ac: 13,
+    hp: 15,
+    maxHp: 15,
+    abilityMods: { STR: 3, DEX: 1 },
+    attacks: [{ name: 'Greataxe', attackMod: 5, damageExpr: '1d12+3' }],
+  });
+  return encounter;
+}
+
+const TEN_ROUNDS: DurationSpec = { rounds: 10, encounterClock: true, label: '10 rounds' };
+
+describe('concentration helpers', () => {
+  it('applies bless tags and refreshes on recast', () => {
+    let encounter = setupEncounter();
+    const helper = new BlessHelper(encounter);
+
+    const cast = helper.cast({
+      casterId: 'pc-1',
+      targetIds: ['pc-2', 'pc-3', 'pc-4'],
+      duration: TEN_ROUNDS,
+      breakReason: 'new-cast',
+    });
+    encounter = cast.state;
+
+    const entry = getConcentration(encounter, 'pc-1');
+    expect(entry).toBeDefined();
+    expect(entry?.spellId).toBe('bless');
+    expect(entry?.targetIds).toEqual(['pc-2', 'pc-3', 'pc-4']);
+    expect(encounter.actors['pc-2']?.tags?.some((tag) => tag.text === 'effect:bless')).toBe(true);
+    expect(encounter.actors['pc-3']?.tags?.some((tag) => tag.text === 'effect:bless')).toBe(true);
+    expect(encounter.actors['pc-4']?.tags?.some((tag) => tag.text === 'effect:bless')).toBe(true);
+    expect(encounter.actors['pc-1']?.tags?.some((tag) => tag.text === 'concentration:bless')).toBe(true);
+
+    const refreshed = new BlessHelper(encounter).cast({
+      casterId: 'pc-1',
+      targetIds: ['pc-2', 'pc-3'],
+      duration: { rounds: 5, encounterClock: true, label: '5 rounds' },
+      breakReason: 'new-cast',
+    });
+    encounter = refreshed.state;
+
+    const refreshedEntry = getConcentration(encounter, 'pc-1');
+    expect(refreshedEntry?.targetIds).toEqual(['pc-2', 'pc-3']);
+    expect(encounter.actors['pc-4']?.tags?.some((tag) => tag.text === 'effect:bless')).toBe(false);
+    expect(refreshed.break?.result.entry?.spellId).toBe('bless');
+    expect(refreshed.effectTags).toHaveLength(2);
+  });
+
+  it("manages hunter's mark cast and transfer", () => {
+    let encounter = setupEncounter();
+
+    const hmHelper = new HuntersMarkHelper(encounter);
+    const cast = hmHelper.cast({
+      casterId: 'pc-1',
+      targetId: 'foe-1',
+      duration: TEN_ROUNDS,
+      breakReason: 'new-cast',
+    });
+    encounter = cast.state;
+
+    const entry = getConcentration(encounter, 'pc-1');
+    expect(entry?.spellId).toBe("hunters-mark");
+    expect(entry?.targetId).toBe('foe-1');
+    expect(encounter.actors['foe-1']?.tags?.some((tag) => tag.text === 'effect:hunters-mark')).toBe(true);
+    expect(encounter.actors['foe-1']?.tags?.some((tag) => tag.text === 'marked-by:pc-1')).toBe(true);
+
+    const transfer = new HuntersMarkHelper(encounter).transfer({ casterId: 'pc-1', targetId: 'foe-2' });
+    encounter = transfer.state;
+
+    const updated = getConcentration(encounter, 'pc-1');
+    expect(updated?.targetId).toBe('foe-2');
+    expect(encounter.actors['foe-1']?.tags?.some((tag) => tag.text.startsWith('effect:hunters-mark'))).toBe(false);
+    expect(encounter.actors['foe-2']?.tags?.some((tag) => tag.text === 'effect:hunters-mark')).toBe(true);
+    expect(encounter.actors['foe-2']?.tags?.some((tag) => tag.text === 'marked-by:pc-1')).toBe(true);
+    expect(transfer.removedTags.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('removeConcentration clears linked tags', () => {
+    let encounter = setupEncounter();
+    const helper = new HuntersMarkHelper(encounter);
+    const cast = helper.cast({ casterId: 'pc-1', targetId: 'foe-1', duration: TEN_ROUNDS });
+    encounter = cast.state;
+    const removal = removeConcentration(encounter, 'pc-1');
+    expect(removal.entry?.spellId).toBe("hunters-mark");
+    const state = removal.state;
+    expect(state.concentration?.['pc-1']).toBeUndefined();
+    expect(state.actors['foe-1']?.tags?.some((tag) => tag.text.startsWith('effect:hunters-mark'))).toBe(false);
+    expect(state.actors['pc-1']?.tags?.some((tag) => tag.text.startsWith('concentration:hunters-mark'))).toBe(false);
+  });
+});

--- a/packages/core/tests/concentration.test.ts
+++ b/packages/core/tests/concentration.test.ts
@@ -21,7 +21,10 @@ describe('concentration helpers', () => {
     const entry = { casterId: 'pc-1', spellName: 'Bless', targetId: 'ally-1' };
 
     const withConcentration = startConcentration(encounter, entry);
-    expect(getConcentration(withConcentration, 'pc-1')).toEqual(entry);
+    expect(getConcentration(withConcentration, 'pc-1')).toMatchObject({
+      ...entry,
+      targetIds: ['ally-1'],
+    });
 
     const cleared = endConcentration(withConcentration, 'pc-1');
     expect(getConcentration(cleared, 'pc-1')).toBeUndefined();


### PR DESCRIPTION
## Summary
- add BlessHelper and HuntersMarkHelper to manage concentration, linked tags, and durations in the core package
- extend encounter state to clean linked tags, support TTL metadata, and apply Hunter's Mark bonus damage automatically
- add `ge` CLI commands for bless, hunter's mark (cast/transfer), and concentration list/break operations with duration parsing helpers

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e40d3a1a188327b0c0de46e8933985