### PR TITLE
chore(characters): add Bruni and Kara

### DIFF
--- a/Characters/Bruni.json
+++ b/Characters/Bruni.json
@@ -1,0 +1,21 @@
+{
+  "name": "Bruni",
+  "level": 3,
+  "xp": 900,
+  "abilities": { "STR": 14, "DEX": 10, "CON": 16, "INT": 10, "WIS": 16, "CHA": 10 },
+  "proficiencies": {
+    "weapons": { "simple": true },
+    "saves": ["WIS", "CHA"],
+    "skills": ["Insight", "Medicine", "Religion"],
+    "expertise": []
+  },
+  "equipped": {
+    "armor": "Chain Mail",
+    "shield": true,
+    "weapon": "Mace",
+    "hitDie": "d8"
+  },
+  "slots": {
+    "max": { "1": 4, "2": 2 }
+  }
+}

--- a/Characters/Kara.json
+++ b/Characters/Kara.json
@@ -1,0 +1,21 @@
+{
+  "name": "Kara",
+  "level": 3,
+  "xp": 900,
+  "abilities": { "STR": 12, "DEX": 16, "CON": 14, "INT": 10, "WIS": 14, "CHA": 8 },
+  "proficiencies": {
+    "weapons": { "simple": true, "martial": true },
+    "saves": ["STR", "DEX"],
+    "skills": ["Athletics", "Perception", "Stealth", "Survival"],
+    "expertise": []
+  },
+  "equipped": {
+    "armor": "Studded Leather",
+    "shield": false,
+    "weapon": "Longbow",
+    "hitDie": "d10"
+  },
+  "slots": {
+    "max": { "1": 3 }
+  }
+}


### PR DESCRIPTION
## Summary
- add a ready-to-load Bruni cleric profile alongside the existing characters
- add a Kara ranger profile with starting gear and spell slots

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e51b09860c832792aa6d80b5bb5584