### PR TITLE
Improve reminder detection using concentration state

### DIFF
--- a/packages/core/tests/reminders.test.ts
+++ b/packages/core/tests/reminders.test.ts
@@ -68,4 +68,28 @@ describe('remindersFor', () => {
     const otherEvent = remindersFor(encounter, 'pc-3', 'pc-2', 'save');
     expect(otherEvent).not.toContain("Reminder: Hunter's Mark (+1d6 on hit vs Borin)");
   });
+
+  it('detects concentration-based reminders when tags are missing', () => {
+    let encounter = setupEncounter();
+    encounter = startBless(encounter, 'pc-2', ['pc-1']);
+    encounter = startHuntersMark(encounter, 'pc-3', 'pc-2');
+
+    const blessed = encounter.actors['pc-1'];
+    const marked = encounter.actors['pc-2'];
+
+    encounter = {
+      ...encounter,
+      actors: {
+        ...encounter.actors,
+        'pc-1': blessed ? { ...blessed, tags: [] } : blessed,
+        'pc-2': marked ? { ...marked, tags: [] } : marked,
+      },
+    };
+
+    const blessFromConcentration = remindersFor(encounter, 'pc-1', null, 'attack');
+    expect(blessFromConcentration).toContain('Reminder: Bless (+d4 to attack roll)');
+
+    const huntersMarkFromConcentration = remindersFor(encounter, 'pc-3', 'pc-2', 'attack');
+    expect(huntersMarkFromConcentration).toContain("Reminder: Hunter's Mark (+1d6 on hit vs Borin)");
+  });
 });


### PR DESCRIPTION
## Summary
- expand Bless and Hunter's Mark reminders to consider concentration entries and normalized tag labels
- add coverage ensuring reminders still fire when effect tags are absent but concentration persists

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e5af7bcbbc8327838afed56d3afc27